### PR TITLE
Git update provider

### DIFF
--- a/SS14.Watchdog.Tests/SS14.Watchdog.Tests.csproj
+++ b/SS14.Watchdog.Tests/SS14.Watchdog.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/SS14.Watchdog/Components/ServerManagement/ServerInstance.cs
+++ b/SS14.Watchdog/Components/ServerManagement/ServerInstance.cs
@@ -100,7 +100,7 @@ namespace SS14.Watchdog.Components.ServerManagement
                         .GetSection($"Servers:Instances:{key}:Updates")
                         .Get<UpdateProviderGitConfiguration>();
 
-                    _updateProvider = new UpdateProviderGit(this, gitConfig, gitLogger);
+                    _updateProvider = new UpdateProviderGit(this, gitConfig, gitLogger, configuration);
                     break;
                 
                 case "Dummy":

--- a/SS14.Watchdog/Components/ServerManagement/ServerInstance.cs
+++ b/SS14.Watchdog/Components/ServerManagement/ServerInstance.cs
@@ -67,7 +67,8 @@ namespace SS14.Watchdog.Components.ServerManagement
 
         public ServerInstance(string key, InstanceConfiguration instanceConfig, IConfiguration configuration,
             ILogger<UpdateProviderJenkins> jenkinsLogger, ServersConfiguration serversConfiguration,
-            ILogger<ServerInstance> logger, IBackgroundTaskQueue taskQueue, ILogger<UpdateProviderLocal> localLogger)
+            ILogger<ServerInstance> logger, IBackgroundTaskQueue taskQueue, ILogger<UpdateProviderLocal> localLogger,
+            ILogger<UpdateProviderGit> gitLogger)
         {
             Key = key;
             _instanceConfig = instanceConfig;
@@ -93,8 +94,15 @@ namespace SS14.Watchdog.Components.ServerManagement
 
                     _updateProvider = new UpdateProviderLocal(this, localConfig, localLogger, configuration);
                     break;
+                
+                case "Git":
+                    var gitConfig = configuration
+                        .GetSection($"Servers:Instances:{key}:Updates")
+                        .Get<UpdateProviderGitConfiguration>();
 
-
+                    _updateProvider = new UpdateProviderGit(this, gitConfig, gitLogger);
+                    break;
+                
                 case "Dummy":
                     _updateProvider = new UpdateProviderDummy();
                     break;

--- a/SS14.Watchdog/Components/ServerManagement/ServerManager.cs
+++ b/SS14.Watchdog/Components/ServerManagement/ServerManager.cs
@@ -22,6 +22,7 @@ namespace SS14.Watchdog.Components.ServerManagement
         private readonly ILogger<ServerManager> _logger;
         private readonly ILogger<UpdateProviderJenkins> _jenkinsLogger;
         private readonly ILogger<UpdateProviderLocal> _localLogger;
+        private readonly ILogger<UpdateProviderGit> _gitLogger;
         private readonly ILogger<ServerInstance> _serverInstanceLogger;
         private readonly IBackgroundTaskQueue _taskQueue;
         private readonly IConfiguration _configuration;
@@ -34,7 +35,7 @@ namespace SS14.Watchdog.Components.ServerManagement
             IOptions<ServersConfiguration> instancesOptions,
             ILogger<ServerManager> logger, IConfiguration configuration, ILogger<UpdateProviderJenkins> jenkinsLogger,
             ILogger<ServerInstance> serverInstanceLogger, IBackgroundTaskQueue taskQueue,
-            ILogger<UpdateProviderLocal> localLogger)
+            ILogger<UpdateProviderLocal> localLogger, ILogger<UpdateProviderGit> gitLogger)
         {
             _logger = logger;
             _configuration = configuration;
@@ -42,6 +43,7 @@ namespace SS14.Watchdog.Components.ServerManagement
             _serverInstanceLogger = serverInstanceLogger;
             _taskQueue = taskQueue;
             _localLogger = localLogger;
+            _gitLogger = gitLogger;
             _serversOptions = instancesOptions.Value;
         }
 
@@ -85,7 +87,7 @@ namespace SS14.Watchdog.Components.ServerManagement
 
                 var instance =
                     new ServerInstance(key, instanceOptions, _configuration, _jenkinsLogger, _serversOptions,
-                        _serverInstanceLogger, _taskQueue, _localLogger);
+                        _serverInstanceLogger, _taskQueue, _localLogger, _gitLogger);
                 _instances.Add(key, instance);
             }
 

--- a/SS14.Watchdog/Components/Updates/UpdateProvider.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProvider.cs
@@ -46,12 +46,6 @@ namespace SS14.Watchdog.Components.Updates
         }
 
         [Pure]
-        protected static string GetBuildFilename(string platform)
-        {
-            return $"SS14.Client_{platform}_x64.zip";
-        }
-        
-        [Pure]
         protected static string GetHostPlatformName()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -81,11 +75,15 @@ namespace SS14.Watchdog.Components.Updates
                     return "x64";
 
                 case Architecture.Arm64:
+                    // Only Linux is supported on ARM64.
+                    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                        throw new PlatformNotSupportedException();
+                    
                     return "ARM64";
 
                 // Any other architecture is unsupported.
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new PlatformNotSupportedException();
             }
         }
         

--- a/SS14.Watchdog/Components/Updates/UpdateProvider.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProvider.cs
@@ -1,3 +1,8 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -35,6 +40,66 @@ namespace SS14.Watchdog.Components.Updates
         protected static string GetBuildFilename(string platform)
         {
             return $"SS14.Client_{platform}_x64.zip";
+        }
+        
+        [Pure]
+        protected static string GetHostPlatformName()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return PlatformNameWindows;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return PlatformNameLinux;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return PlatformNameMacOS;
+            }
+
+            throw new PlatformNotSupportedException();
+        }
+
+        [Pure]
+        protected static string GetHostArchitectureName()
+        {
+            switch (RuntimeInformation.OSArchitecture)
+            {
+                case Architecture.X64:
+                    return "x64";
+
+                case Architecture.Arm64:
+                    return "ARM64";
+
+                // Any other architecture is unsupported.
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+        
+        [Pure]
+        protected static string GetFileHash(string filePath)
+        {
+            using var file = File.OpenRead(filePath);
+            using var sha = SHA256.Create();
+
+            return ByteArrayToString(sha.ComputeHash(file));
+        }
+
+        [Pure]
+        // https://stackoverflow.com/a/311179/4678631
+        private static string ByteArrayToString(byte[] ba)
+        {
+            var hex = new StringBuilder(ba.Length * 2);
+            foreach (var b in ba)
+            {
+                hex.AppendFormat("{0:x2}", b);
+            }
+
+            return hex.ToString();
         }
     }
 }

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -156,7 +156,7 @@ namespace SS14.Watchdog.Components.Updates
 
                 _logger.LogTrace("Extracting zip file");
 
-                var serverPackage = Path.Combine(_repoPath, "releases", $"SS14.Server_{GetHostPlatformName()}_{GetHostArchitectureName()}.zip");
+                var serverPackage = Path.Combine(_repoPath, "release", $"SS14.Server_{GetHostPlatformName()}_{GetHostArchitectureName()}.zip");
 
                 var stream = File.Open(serverPackage, FileMode.Open);
                 

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -69,15 +69,16 @@ namespace SS14.Watchdog.Components.Updates
 
                 using var repository = new Repository(_repoPath);
 
+                var remote = repository.Network.Remotes["origin"];
+                Commands.Fetch(repository, remote.Name, remote.FetchRefSpecs.Select(x => x.Specification),
+                    null, null);
 
                 _logger.LogTrace("Updating...");
-                
-                var localBranch = repository.Branches[_branch];
-                var remoteBranch = localBranch.TrackedBranch;
 
-                localBranch = Commands.Checkout(repository, localBranch);
-                repository.Merge(remoteBranch,
-                    new Signature("Watchdog", "telecommunications@spacestation14.io", DateTimeOffset.Now), null);
+                Commands.Pull(repository, new Signature("Watchdog", "telecommunications@spacestation14.io", DateTimeOffset.Now), null);
+                var localBranch = Commands.Checkout(repository, repository.Branches[_branch]);
+                
+                _logger.LogDebug($"Went from {currentVersion} to {localBranch.Tip}");
 
                 foreach (var submodule in repository.Submodules)
                 {

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -74,8 +74,8 @@ namespace SS14.Watchdog.Components.Updates
                     null, null);
 
                 _logger.LogTrace("Updating...");
-
-                Commands.Pull(repository, new Signature("Watchdog", "telecommunications@spacestation14.io", DateTimeOffset.Now), null);
+                
+                Commands.Pull(repository, new Signature("Watchdog", "N/A", DateTimeOffset.Now), null);
                 var localBranch = Commands.Checkout(repository, repository.Branches[_branch]);
                 
                 _logger.LogDebug($"Went from {currentVersion} to {localBranch.Tip}");
@@ -160,9 +160,6 @@ namespace SS14.Watchdog.Components.Updates
                 var serverPackage = Path.Combine(_repoPath, "release", $"SS14.Server_{GetHostPlatformName()}_{GetHostArchitectureName()}.zip");
 
                 var stream = File.Open(serverPackage, FileMode.Open);
-                
-                // Reset file position so we can extract.
-                stream.Seek(0, SeekOrigin.Begin);
 
                 // Actually extract.
                 using var archive = new ZipArchive(stream, ZipArchiveMode.Read);

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using LibGit2Sharp;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Mono.Unix;
 using SS14.Watchdog.Components.ServerManagement;
 using SS14.Watchdog.Configuration.Updates;
 
@@ -172,16 +173,14 @@ namespace SS14.Watchdog.Components.Updates
                     RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     // chmod +x Robust.Server
-
+                    
                     var rsPath = Path.Combine(binPath, "Robust.Server");
                     if (File.Exists(rsPath))
                     {
-                        var proc = Process.Start(new ProcessStartInfo("chmod")
-                        {
-                            ArgumentList = {"+x", rsPath}
-                        });
-
-                        await proc!.WaitForExitAsync(cancel);
+                        var f = new UnixFileInfo(rsPath);
+                        f.FileAccessPermissions |=
+                            FileAccessPermissions.UserExecute | FileAccessPermissions.GroupExecute |
+                            FileAccessPermissions.OtherExecute;
                     }
                 }
 

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -1,14 +1,15 @@
+using System;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using LibGit2Sharp;
-using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.Extensions.Logging;
 using SS14.Watchdog.Components.ServerManagement;
 using SS14.Watchdog.Configuration.Updates;
-using SS14.Watchdog.Utility;
 
 namespace SS14.Watchdog.Components.Updates
 {
@@ -56,47 +57,140 @@ namespace SS14.Watchdog.Components.Updates
 
         public override async Task<RevisionDescription?> RunUpdateAsync(string? currentVersion, string binPath, CancellationToken cancel = default)
         {
-            if (currentVersion == null)
-                TryClone();
-
-            using var repository = new Repository(_repoPath);
-            var localBranch = repository.Branches[_branch];
-            var remoteBranch = localBranch.TrackedBranch;
-
-            Commands.Checkout(repository, localBranch);
-            repository.Merge(remoteBranch, null, null);
-
-            foreach (var submodule in repository.Submodules)
+            try
             {
-                repository.Submodules.Update(submodule.Name, null);
+                if (currentVersion == null)
+                    TryClone();
+
+                _logger.LogTrace("Updating...");
+
+                using var repository = new Repository(_repoPath);
+                var localBranch = repository.Branches[_branch];
+                var remoteBranch = localBranch.TrackedBranch;
+
+                Commands.Checkout(repository, localBranch);
+                repository.Merge(remoteBranch,
+                    new Signature("Watchdog", "telecommunications@spacestation14.io", DateTimeOffset.Now), null);
+
+                foreach (var submodule in repository.Submodules)
+                {
+                    repository.Submodules.Update(submodule.Name, null);
+                }
+
+                // Now we build and package it.
+
+                _logger.LogTrace("Building...");
+
+                var process = new Process
+                {
+                    StartInfo =
+                    {
+                        FileName = "python", CreateNoWindow = true, UseShellExecute = true,
+                        WorkingDirectory = _repoPath,
+                        Arguments = "Tools/package_release_build.py -p windows mac linux linux-arm64"
+                    },
+                };
+
+                var binariesPath = Path.Combine(_serverInstance.InstanceDir, "binaries");
+                
+                process.Start();
+                await process.WaitForExitAsync(cancel);
+
+                foreach (var file in Directory.EnumerateFiles(Path.Combine(_repoPath, "release")))
+                {
+                    File.Move(file, Path.Combine(binariesPath, Path.GetFileName(file)), true);
+                }
+                
+                _logger.LogTrace("Applying server update.");
+                
+                if (Directory.Exists(binPath))
+                {
+                    Directory.Delete(binPath, true);
+                }
+
+                Directory.CreateDirectory(binPath);
+
+                _logger.LogTrace("Extracting zip file");
+
+                var name = $"SS14.Server_{GetHostPlatformName()}_{GetHostArchitectureName()}.zip";
+
+                var stream = File.Open(Path.Combine(binariesPath, name), FileMode.Open);
+                
+                // Reset file position so we can extract.
+                stream.Seek(0, SeekOrigin.Begin);
+
+                // Actually extract.
+                using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+                archive.ExtractToDirectory(binPath);
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                    RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    // chmod +x Robust.Server
+
+                    var rsPath = Path.Combine(binPath, "Robust.Server");
+                    if (File.Exists(rsPath))
+                    {
+                        var proc = Process.Start(new ProcessStartInfo("chmod")
+                        {
+                            ArgumentList = {"+x", rsPath}
+                        });
+
+                        await proc!.WaitForExitAsync(cancel);
+                    }
+                }
+
+                DownloadInfoPair? GetInfoPair(string platform)
+                {
+                    var fileName = GetBuildFilename(platform);
+                    var diskFileName = Path.Combine(binariesPath, fileName);
+
+                    if (!File.Exists(diskFileName))
+                    {
+                        return null;
+                    }
+
+                    var download = Path.Combine(binariesPath, fileName);
+                    var hash = GetFileHash(diskFileName);
+
+                    _logger.LogTrace("SHA256 hash for {fileName} is {hash}", fileName, hash);
+
+                    return new DownloadInfoPair(download, hash);
+                }
+
+                var revisionDescription = new RevisionDescription(
+                    localBranch.Tip.ToString(),
+                    GetInfoPair(PlatformNameWindows),
+                    GetInfoPair(PlatformNameLinux),
+                    GetInfoPair(PlatformNameMacOS));
+
+                // ReSharper disable once RedundantTypeArgumentsOfMethod
+                return revisionDescription;
             }
-            
-            // Now we build and package it.
-
-            var process = new Process
+            catch (Exception e)
             {
-                StartInfo = {FileName = "python", RedirectStandardInput = false,
-                    RedirectStandardOutput = true, CreateNoWindow = true, UseShellExecute = true,
-                    WorkingDirectory = _repoPath, Arguments = "Tools/package_release_build.py -p windows mac linux linux-arm64"
-                },
-            };
+                _logger.LogError(e, "Failed to run update!");
 
-            process.Start();
-            await process.WaitForExitAsync(cancel);
-
-            return null;
+                return null;
+            }
         }
         
         private void TryClone()
         {
-            Repository.Clone(_baseUrl, _repoPath);
+            _logger.LogTrace("Cloning git repository...");
+            
+            if(Directory.Exists(_repoPath))
+                Directory.Delete(_repoPath, true);
+            
+            Repository.Clone(_baseUrl, _repoPath, new CloneOptions(){RecurseSubmodules = true});
             
             using var repository = new Repository(_repoPath);
             var remote = repository.Network.Remotes["origin"];
             var refSpecs = remote.FetchRefSpecs.Select(x => x.Specification);
             Commands.Fetch(repository, remote.Name, refSpecs, null, null);
             var remoteBranch = repository.Branches[$"origin/{_branch}"];
-            var localBranch = repository.CreateBranch(_branch);
+            var localBranch = repository.Branches.Any(x => x.FriendlyName == _branch) 
+                ? repository.Branches[_branch] : repository.CreateBranch(_branch);
             repository.Branches.Update(localBranch, b => b.TrackedBranch = remoteBranch.CanonicalName);
         }
     }

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -83,6 +83,7 @@ namespace SS14.Watchdog.Components.Updates
 
                 foreach (var submodule in repository.Submodules)
                 {
+                    _logger.LogTrace($"Updating submodule {submodule.Name}");
                     repository.Submodules.Update(submodule.Name, null);
                 }
 

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -66,7 +66,7 @@ namespace SS14.Watchdog.Components.Updates
             try
             {
                 if (!Repository.IsValid(_repoPath) || currentVersion == null)
-                    TryClone(cancel);
+                    await TryClone(cancel);
 
                 using var repository = new Repository(_repoPath);
 
@@ -160,7 +160,7 @@ namespace SS14.Watchdog.Components.Updates
 
                 var serverPackage = Path.Combine(_repoPath, "release", $"SS14.Server_{GetHostPlatformName()}_{GetHostArchitectureName()}.zip");
 
-                var stream = File.Open(serverPackage, FileMode.Open);
+                await using var stream = File.Open(serverPackage, FileMode.Open);
 
                 // Actually extract.
                 using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
@@ -224,7 +224,7 @@ namespace SS14.Watchdog.Components.Updates
             public string ForkId { get; set; }
         }
         
-        private async void TryClone(CancellationToken cancel = default)
+        private async Task TryClone(CancellationToken cancel = default)
         {
             _logger.LogTrace("Cloning git repository...");
             

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SS14.Watchdog.Components.Updates
+{
+    public class UpdateProviderGit : UpdateProvider
+    {
+        public override Task<bool> CheckForUpdateAsync(string? currentVersion, CancellationToken cancel = default)
+        {
+        }
+
+        public override Task<RevisionDescription?> RunUpdateAsync(string? currentVersion, string binPath, CancellationToken cancel = default)
+        {
+        }
+    }
+}

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -1,16 +1,103 @@
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using LibGit2Sharp;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.Extensions.Logging;
+using SS14.Watchdog.Components.ServerManagement;
+using SS14.Watchdog.Configuration.Updates;
+using SS14.Watchdog.Utility;
 
 namespace SS14.Watchdog.Components.Updates
 {
     public class UpdateProviderGit : UpdateProvider
     {
+        private readonly ServerInstance _serverInstance;
+        private readonly string _baseUrl;
+        private readonly string _branch;
+        private readonly ILogger<UpdateProviderGit> _logger;
+        private readonly string _repoPath;
+        
+        public UpdateProviderGit(ServerInstance serverInstanceInstance, UpdateProviderGitConfiguration configuration, ILogger<UpdateProviderGit> logger)
+        {
+            _serverInstance = serverInstanceInstance;
+            _baseUrl = configuration.BaseUrl;
+            _branch = configuration.Branch;
+            _logger = logger;
+            _repoPath = Path.Combine(_serverInstance.InstanceDir, "source");
+        }
+        
         public override Task<bool> CheckForUpdateAsync(string? currentVersion, CancellationToken cancel = default)
         {
+            if (currentVersion == null)
+                return Task.FromResult(true);
+
+            var logMessage = "";
+            var update = false;
+            
+            using (var repository = new Repository(_repoPath))
+            {
+                var remote = repository.Network.Remotes["origin"];
+                var refSpecs = remote.FetchRefSpecs.Select(x => x.Specification);
+                Commands.Fetch(repository, remote.Name, refSpecs, null, logMessage);
+                
+                var localBranch = repository.Branches[_branch];
+                var remoteBranch = localBranch.TrackedBranch;
+
+                if (localBranch.Tip != remoteBranch.Tip)
+                    update = true;
+            }
+            
+            _logger.LogInformation(logMessage);
+            return Task.FromResult(update);
         }
 
-        public override Task<RevisionDescription?> RunUpdateAsync(string? currentVersion, string binPath, CancellationToken cancel = default)
+        public override async Task<RevisionDescription?> RunUpdateAsync(string? currentVersion, string binPath, CancellationToken cancel = default)
         {
+            if (currentVersion == null)
+                TryClone();
+
+            using var repository = new Repository(_repoPath);
+            var localBranch = repository.Branches[_branch];
+            var remoteBranch = localBranch.TrackedBranch;
+
+            Commands.Checkout(repository, localBranch);
+            repository.Merge(remoteBranch, null, null);
+
+            foreach (var submodule in repository.Submodules)
+            {
+                repository.Submodules.Update(submodule.Name, null);
+            }
+            
+            // Now we build and package it.
+
+            var process = new Process
+            {
+                StartInfo = {FileName = "python", RedirectStandardInput = false,
+                    RedirectStandardOutput = true, CreateNoWindow = true, UseShellExecute = true,
+                    WorkingDirectory = _repoPath, Arguments = "Tools/package_release_build.py -p windows mac linux linux-arm64"
+                },
+            };
+
+            process.Start();
+            await process.WaitForExitAsync(cancel);
+
+            return null;
+        }
+        
+        private void TryClone()
+        {
+            Repository.Clone(_baseUrl, _repoPath);
+            
+            using var repository = new Repository(_repoPath);
+            var remote = repository.Network.Remotes["origin"];
+            var refSpecs = remote.FetchRefSpecs.Select(x => x.Specification);
+            Commands.Fetch(repository, remote.Name, refSpecs, null, null);
+            var remoteBranch = repository.Branches[$"origin/{_branch}"];
+            var localBranch = repository.CreateBranch(_branch);
+            repository.Branches.Update(localBranch, b => b.TrackedBranch = remoteBranch.CanonicalName);
         }
     }
 }

--- a/SS14.Watchdog/Components/Updates/UpdateProviderJenkins.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderJenkins.cs
@@ -195,26 +195,5 @@ namespace SS14.Watchdog.Components.Updates
 
             return jobInfo.LastSuccessfulBuild;
         }
-
-        [Pure]
-        private static string GetHostPlatformName()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return PlatformNameWindows;
-            }
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return PlatformNameLinux;
-            }
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return PlatformNameMacOS;
-            }
-
-            throw new PlatformNotSupportedException();
-        }
     }
 }

--- a/SS14.Watchdog/Components/Updates/UpdateProviderJenkins.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderJenkins.cs
@@ -89,7 +89,7 @@ namespace SS14.Watchdog.Components.Updates
                 // Create temporary file to download binary into (not doing this in memory).
                 await using var tempFile = File.Open(Path.GetTempFileName(), FileMode.Open, FileAccess.ReadWrite);
                 // Download URI for server binary.
-                var serverDownload = new Uri(downloadRootUri, $"SS14.Server_{GetHostPlatformName()}_x64.zip");
+                var serverDownload = new Uri(downloadRootUri, $"SS14.Server_{GetHostPlatformName()}_{GetHostArchitectureName()}.zip");
 
                 _logger.LogTrace("Downloading server binary from {download} to {tempFile}", serverDownload,
                     tempFile.Name);

--- a/SS14.Watchdog/Components/Updates/UpdateProviderLocal.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderLocal.cs
@@ -82,25 +82,5 @@ namespace SS14.Watchdog.Components.Updates
             // ReSharper disable once RedundantTypeArgumentsOfMethod
             return Task.FromResult<RevisionDescription?>(revisionDescription);
         }
-
-        private static string GetFileHash(string filePath)
-        {
-            using var file = File.OpenRead(filePath);
-            using var sha = SHA256.Create();
-
-            return ByteArrayToString(sha.ComputeHash(file));
-        }
-
-        // https://stackoverflow.com/a/311179/4678631
-        private static string ByteArrayToString(byte[] ba)
-        {
-            var hex = new StringBuilder(ba.Length * 2);
-            foreach (var b in ba)
-            {
-                hex.AppendFormat("{0:x2}", b);
-            }
-
-            return hex.ToString();
-        }
     }
 }

--- a/SS14.Watchdog/Configuration/Updates/UpdateProviderGitConfiguration.cs
+++ b/SS14.Watchdog/Configuration/Updates/UpdateProviderGitConfiguration.cs
@@ -1,0 +1,7 @@
+namespace SS14.Watchdog.Configuration.Updates
+{
+    public class UpdateProviderGitConfiguration
+    {
+        
+    }
+}

--- a/SS14.Watchdog/Configuration/Updates/UpdateProviderGitConfiguration.cs
+++ b/SS14.Watchdog/Configuration/Updates/UpdateProviderGitConfiguration.cs
@@ -2,6 +2,7 @@ namespace SS14.Watchdog.Configuration.Updates
 {
     public class UpdateProviderGitConfiguration
     {
-        
+        public string BaseUrl { get; set; } = null!;
+        public string Branch { get; set; } = "master";
     }
 }

--- a/SS14.Watchdog/SS14.Watchdog.csproj
+++ b/SS14.Watchdog/SS14.Watchdog.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <Nullable>enable</Nullable>
         <Version>0.2.0</Version>
     </PropertyGroup>

--- a/SS14.Watchdog/SS14.Watchdog.csproj
+++ b/SS14.Watchdog/SS14.Watchdog.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
+      <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
       <PackageReference Include="NetEscapades.Configuration.Yaml" Version="2.0.0" />
     </ItemGroup>
 

--- a/SS14.Watchdog/appsettings.Development.yml
+++ b/SS14.Watchdog/appsettings.Development.yml
@@ -19,7 +19,7 @@ Servers:
       #Updates:
       #  CurrentVersion: "honk2"
       
-      UpdateType: "Jenkins"
+      UpdateType: "Git"
       Updates:
-        BaseUrl: "https://builds.spacestation14.io/jenkins"
-        JobName: "SS14 Content"
+        BaseUrl: "https://github.com/space-wizards/space-station-14.git"
+        Branch: "master"

--- a/SS14.Watchdog/appsettings.Development.yml
+++ b/SS14.Watchdog/appsettings.Development.yml
@@ -19,7 +19,12 @@ Servers:
       #Updates:
       #  CurrentVersion: "honk2"
       
-      UpdateType: "Git"
+      #UpdateType: "Git"
+      #Updates:
+      #  BaseUrl: "https://github.com/space-wizards/space-station-14.git"
+      #  Branch: "master"
+
+      UpdateType: "Jenkins"
       Updates:
-        BaseUrl: "https://github.com/space-wizards/space-station-14.git"
-        Branch: "master"
+        BaseUrl: "https://builds.spacestation14.io/jenkins"
+        JobName: "SS14 Content"


### PR DESCRIPTION
Adds a way for the watchdog to download the game's source from a git repository, build and package it.
Mostly useful for smaller servers that might find jenkins unnecessary/difficult to deal with.

Adds libgit2sharp as a dependency.

~~Oh yeah also updates the watchdog to .NET 5.0. Works just fine!~~