### PR TITLE
Return of Git: Fixed Git-based update method

### DIFF
--- a/SS14.Watchdog/Components/Updates/UpdateProvider.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProvider.cs
@@ -18,10 +18,7 @@ namespace SS14.Watchdog.Components.Updates
     public abstract class UpdateProvider
     {
         protected const string ClientZipName = "SS14.Client.zip";
-
-        protected const string PlatformNameWindows = "Windows";
-        protected const string PlatformNameLinux = "Linux";
-        protected const string PlatformNameMacOS = "macOS";
+        protected string ServerZipName => $"SS14.Server_{GetHostSS14RID()}.zip";
 
         /// <summary>
         ///     Check whether an update is available.
@@ -47,42 +44,51 @@ namespace SS14.Watchdog.Components.Updates
         }
 
         [Pure]
-        protected static string GetHostPlatformName()
+        protected static string GetHostSS14RID()
+        {
+            return GetHostPlatformName() + "-" + GetHostArchitectureName();
+        }
+
+        [Pure]
+        private static string GetHostPlatformName()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return PlatformNameWindows;
+                return "win";
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                return PlatformNameLinux;
+                return "linux";
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return PlatformNameMacOS;
+                return "osx";
             }
 
             throw new PlatformNotSupportedException();
         }
 
         [Pure]
-        protected static string GetHostArchitectureName()
+        private static string GetHostArchitectureName()
         {
             switch (RuntimeInformation.OSArchitecture)
             {
+                case Architecture.X86:
+                    return "x86";
+
                 case Architecture.X64:
                     return "x64";
 
-                case Architecture.Arm64:
-                    // Only Linux is supported on ARM64.
-                    if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                        throw new PlatformNotSupportedException();
-                    
-                    return "ARM64";
+                case Architecture.Arm:
+                    return "arm";
 
-                // Any other architecture is unsupported.
+                case Architecture.Arm64:
+                    return "arm64";
+
+                // Other architectures not supported.
+                // Even some of these aren't but there's no reason not to force it to fail here.
                 default:
                     throw new PlatformNotSupportedException();
             }

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -140,7 +140,7 @@ namespace SS14.Watchdog.Components.Updates
                 // The --depth=1 is a performance cheat. Works though.
                 await CommandHelperChecked("Failed initial clone!", null, "git", new string[] {"clone", "--depth=1", _baseUrl, _repoPath}, cancel);
                 await CommandHelperChecked("Failed branch checkout!", _repoPath, "git", new string[] {"checkout", _branch}, cancel);
-                await CommandHelperChecked("Failed submodule update!", _repoPath, "git", new string[] {"submodule", "update", "--init", "--depth=1", "--recursive"}, cancel);
+                await GitCheckedSubmoduleUpdate(cancel);
             }
             catch (Exception)
             {

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -35,7 +35,7 @@ namespace SS14.Watchdog.Components.Updates
             _configuration = config;
         }
 
-        private async Task<int> CommandHelper(string? cd, string command, string[] args, CancellationToken cancel = default)
+        private async Task<int> CommandHelper(string cd, string command, string[] args, CancellationToken cancel = default)
         {
             var si = new ProcessStartInfo {
                 FileName = command, CreateNoWindow = true, UseShellExecute = true,
@@ -138,7 +138,7 @@ namespace SS14.Watchdog.Components.Updates
                 // NOTE: These are expected to prepare everything including submodules,
                 // because this is used for orbital nuking in the event of an update issue.
                 // The --depth=1 is a performance cheat. Works though.
-                await CommandHelperChecked("Failed initial clone!", null, "git", new string[] {"clone", "--depth=1", _baseUrl, _repoPath}, cancel);
+                await CommandHelperChecked("Failed initial clone!", "", "git", new string[] {"clone", "--depth=1", _baseUrl, _repoPath}, cancel);
                 await CommandHelperChecked("Failed branch checkout!", _repoPath, "git", new string[] {"checkout", _branch}, cancel);
                 await GitCheckedSubmoduleUpdate(cancel);
             }
@@ -232,7 +232,6 @@ namespace SS14.Watchdog.Components.Updates
                 // Now we build and package it.
 
                 // Platform to build the server for.
-                var serverPlatform = RuntimeInformation.RuntimeIdentifier;
 
                 var binariesPath = Path.Combine(_serverInstance.InstanceDir, "binaries");
                 
@@ -248,7 +247,7 @@ namespace SS14.Watchdog.Components.Updates
                 
                 _logger.LogTrace("Building server packages...");
                 
-                await CommandHelperChecked("Failed to build server packages", _repoPath, "python", new string[] {"Tools/package_server_build.py", "-p", serverPlatform}, cancel);
+                await CommandHelperChecked("Failed to build server packages", _repoPath, "python", new string[] {"Tools/package_server_build.py", "-p", GetHostSS14RID()}, cancel);
 
                 _logger.LogTrace("Applying server update.");
                 
@@ -261,7 +260,7 @@ namespace SS14.Watchdog.Components.Updates
 
                 _logger.LogTrace("Extracting zip file");
 
-                var serverPackage = Path.Combine(_repoPath, "release", $"SS14.Server_{serverPlatform}.zip");
+                var serverPackage = Path.Combine(_repoPath, "release", ServerZipName);
 
                 await using var stream = File.Open(serverPackage, FileMode.Open);
 

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -8,7 +8,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using LibGit2Sharp;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Mono.Unix;
@@ -35,28 +34,157 @@ namespace SS14.Watchdog.Components.Updates
             _repoPath = Path.Combine(_serverInstance.InstanceDir, "source");
             _configuration = config;
         }
+
+        private async Task<int> CommandHelper(string? cd, string command, string[] args, CancellationToken cancel = default)
+        {
+            var si = new ProcessStartInfo {
+                FileName = command, CreateNoWindow = true, UseShellExecute = true,
+                WorkingDirectory = cd
+            };
+            // MSDN lied to me! https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.argumentlist?view=net-6.0
+            foreach (var s in args)
+                si.ArgumentList.Add(s);
+            var proc = new Process
+            {
+                StartInfo = si
+            };
+            proc.Start();
+            await proc.WaitForExitAsync(cancel);
+            if (cancel.IsCancellationRequested)
+                return 127;
+            return proc.ExitCode;
+        }
+
+        private async Task CommandHelperChecked(string reason, string cd, string command, string[] args, CancellationToken cancel = default)
+        {
+            int exitCode;
+            try
+            {
+                exitCode = await CommandHelper(cd, command, args, cancel);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(reason, ex);
+            }
+            if (exitCode != 0)
+            {
+                throw new Exception(reason);
+            }
+        }
+
+        private async Task<string> CommandHelperCheckedStdout(string reason, string cd, string command, string[] args)
+        {
+            try
+            {
+                var si = new ProcessStartInfo {
+                    FileName = command, CreateNoWindow = true,
+                    WorkingDirectory = cd,
+                    RedirectStandardOutput = true
+                };
+                foreach (var s in args)
+                    si.ArgumentList.Add(s);
+                var proc = new Process
+                {
+                    StartInfo = si
+                };
+                proc.Start();
+                var text = proc.StandardOutput.ReadToEnd();
+                await proc.WaitForExitAsync();
+                if (proc.ExitCode != 0)
+                {
+                    throw new Exception($"Exit code: {proc.ExitCode}");
+                }
+                return text;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(reason, ex);
+            }
+        }
+
+        // Git actions
+
+        private async Task<bool> GitCheckRepositoryValid()
+        {
+            try
+            {
+                return await CommandHelper(_repoPath, "git", new string[] {"status"}) == 0;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        private async Task<bool> GitFetchOrigin()
+        {
+            return await CommandHelper(_repoPath, "git", new string[] {"fetch", _baseUrl, _branch}) == 0;
+        }
+
+        private async Task GitCheckedSubmoduleUpdate(CancellationToken cancel = default)
+        {
+            await CommandHelperChecked("Failed submodule update!", _repoPath, "git", new string[] {"submodule", "update", "--init", "--depth=1", "--recursive"}, cancel);
+        }
         
+        private async Task TryClone(CancellationToken cancel = default)
+        {
+            _logger.LogTrace("Cloning git repository...");
+            
+            if(Directory.Exists(_repoPath))
+                Directory.Delete(_repoPath, true);
+
+            try
+            {
+                // NOTE: These are expected to prepare everything including submodules,
+                // because this is used for orbital nuking in the event of an update issue.
+                // The --depth=1 is a performance cheat. Works though.
+                await CommandHelperChecked("Failed initial clone!", null, "git", new string[] {"clone", "--depth=1", _baseUrl, _repoPath}, cancel);
+                await CommandHelperChecked("Failed branch checkout!", _repoPath, "git", new string[] {"checkout", _branch}, cancel);
+                await CommandHelperChecked("Failed submodule update!", _repoPath, "git", new string[] {"submodule", "update", "--init", "--depth=1", "--recursive"}, cancel);
+            }
+            catch (Exception)
+            {
+                if(Directory.Exists(_repoPath))
+                    Directory.Delete(_repoPath, true);
+                throw;
+            }
+        }
+
+        private async Task<string?> GitHead(string head)
+        {
+            try
+            {
+                return (await CommandHelperCheckedStdout("", _repoPath, "git", new string[] {"rev-parse", head})).Trim();
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        // Updater and checker
+
         public override async Task<bool> CheckForUpdateAsync(string? currentVersion, CancellationToken cancel = default)
         {
-            if (!Repository.IsValid(_repoPath) || currentVersion == null)
+            if ((!(await GitCheckRepositoryValid())) || currentVersion == null)
                 return true;
-            
 
-            var logMessage = "";
             var update = false;
-                
-            using var repository = new Repository(_repoPath);
-            var remote = repository.Network.Remotes["origin"];
-            var refSpecs = remote.FetchRefSpecs.Select(x => x.Specification);
-            await Task.Run(() => Commands.Fetch(repository, remote.Name, refSpecs, null, logMessage), cancel);
-                
-            var localBranch = repository.Branches[_branch];
-            var remoteBranch = localBranch.TrackedBranch;
 
-            if (localBranch.Tip != remoteBranch.Tip || currentVersion != remoteBranch.Tip.ToString())
+            if (!await GitFetchOrigin())
+            {
+                // Maybe the server's not up right now.
+                return false;
+            }
+
+            var head = await GitHead("HEAD");
+            var fetchHead = await GitHead("FETCH_HEAD");
+            if (head != fetchHead || currentVersion != fetchHead)
+            {
                 update = true;
-                
-            _logger.LogInformation(logMessage);
+            }
+
+            _logger.LogInformation($"Update check: {head ?? "No head"}, {fetchHead ?? "No fetch-head"} - updating: {update}");
             return update;
         }
 
@@ -64,92 +192,63 @@ namespace SS14.Watchdog.Components.Updates
         {
             try
             {
-                if (!Repository.IsValid(_repoPath) || currentVersion == null)
-                    await TryClone(cancel);
-
-                using var repository = new Repository(_repoPath);
-
-                var remote = repository.Network.Remotes["origin"];
-                await Task.Run(() => Commands.Fetch(repository, remote.Name, remote.FetchRefSpecs.Select(x => x.Specification),
-                    null, null), cancel);
-
-                _logger.LogTrace("Updating...");
-                
-                await Task.Run(() => Commands.Pull(repository, new Signature("Watchdog", "N/A", DateTimeOffset.Now), null), cancel);
-                var localBranch = Commands.Checkout(repository, repository.Branches[_branch]);
-                
-                _logger.LogDebug($"Went from {currentVersion} to {localBranch.Tip}");
-
-                foreach (var submodule in repository.Submodules)
+                var isFresh = false;
+                if ((!(await GitCheckRepositoryValid())) || currentVersion == null)
                 {
-                    _logger.LogTrace($"Updating submodule {submodule.Name}");
-                    repository.Submodules.Update(submodule.Name, null);
+                    await TryClone(cancel);
+                    isFresh = true;
                 }
 
-                using var engineRepository = new Repository(Path.Combine(_repoPath, "RobustToolbox"));
-                
-                // Fetch engine tags.
-                Commands.Fetch(engineRepository, "origin", remote.FetchRefSpecs.Select(x => x.Specification),
-                    new FetchOptions(){TagFetchMode = TagFetchMode.All}, null);
-                
-                var engineVersion = engineRepository.Describe(engineRepository.Branches["master"].Tip, 
-                                        new DescribeOptions(){MinimumCommitIdAbbreviatedSize = 0, Strategy = DescribeStrategy.Tags})?.Trim()
-                                    ?? throw new NullReferenceException("Can't find version for engine submodule.");
+                _logger.LogTrace("Updating...");
 
-                if (!engineVersion.StartsWith('v'))
-                    throw new InvalidDataException($"Engine submodule tag \"{engineVersion}\" doesn't start with v!");
+                // NOTE: A race condition could happen here if an update check is performed while we're running an update.
+                // The solution is that the update check solely occurs on FETCH_HEAD.
+                // Therefore, the `git reset --hard FETCH_HEAD` is assumed to either provide one consistent HEAD or error.
 
-                engineVersion = engineVersion.Substring(1);
+                if (!isFresh)
+                {
+                    try
+                    {
+                        // Don't allow these to be cancelled as they could probably corrupt the repository.
+                        if (!(await GitFetchOrigin()))
+                            throw new Exception("Could not fetch origin");
+                        await CommandHelperChecked("Failed reset to fetch-head", _repoPath, "git", new string[] {"reset", "--hard", "FETCH_HEAD"});
+                        await GitCheckedSubmoduleUpdate();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning($"Failed git submodule update: {ex}");
+                        _logger.LogWarning($"Nuking the repository from orbit to recover!");
+                        await TryClone(cancel);
+                    }
+                }
+
+                var actualConfirmedHead = await GitHead("HEAD");
+                if (actualConfirmedHead == null)
+                    throw new Exception("Head disappeared!");
+
+                _logger.LogDebug($"Went from {currentVersion} to {actualConfirmedHead}");
 
                 // Now we build and package it.
 
-                var processClientBuild = new Process
-                {
-                    StartInfo =
-                    {
-                        FileName = "python", CreateNoWindow = true, UseShellExecute = true,
-                        WorkingDirectory = _repoPath,
-                        Arguments = "Tools/package_client_build.py"
-                    },
-                };
-
                 // Platform to build the server for.
-                var serverPlatform = GetHostPlatformName() switch
-                {
-                    PlatformNameWindows => "windows",
-                    PlatformNameMacOS => "mac",
-                    PlatformNameLinux => RuntimeInformation.OSArchitecture == Architecture.Arm64
-                        ? "linux-arm64"
-                        : "linux",
-                    _ => throw new PlatformNotSupportedException()
-                };
-
-                var processServerBuild = new Process
-                {
-                    StartInfo =
-                    {
-                        FileName = "python", CreateNoWindow = true, UseShellExecute = true,
-                        WorkingDirectory = _repoPath,
-                        Arguments = $"Tools/package_server_build.py -p {serverPlatform}"
-                    },
-                };
+                var serverPlatform = RuntimeInformation.RuntimeIdentifier;
 
                 var binariesPath = Path.Combine(_serverInstance.InstanceDir, "binaries");
                 
+                // If you get an error here: You need a BaseUrl in the root of appsettings.yml that represents the public URL of the watchdog server.
                 var binariesRoot = new Uri(new Uri(_configuration["BaseUrl"]),
                     $"instances/{_serverInstance.Key}/binaries/");
                 
                 _logger.LogTrace("Building client packages...");
                 
-                processClientBuild.Start();
-                await processClientBuild.WaitForExitAsync(cancel);
+                await CommandHelperChecked("Failed to build client packages", _repoPath, "python", new string[] {"Tools/package_client_build.py"}, cancel);
                 
                 File.Move(Path.Combine(_repoPath, "release", ClientZipName), Path.Combine(binariesPath, ClientZipName), true);
                 
                 _logger.LogTrace("Building server packages...");
                 
-                processServerBuild.Start();
-                await processServerBuild.WaitForExitAsync(cancel);
+                await CommandHelperChecked("Failed to build server packages", _repoPath, "python", new string[] {"Tools/package_server_build.py", "-p", serverPlatform}, cancel);
 
                 _logger.LogTrace("Applying server update.");
                 
@@ -162,7 +261,7 @@ namespace SS14.Watchdog.Components.Updates
 
                 _logger.LogTrace("Extracting zip file");
 
-                var serverPackage = Path.Combine(_repoPath, "release", $"SS14.Server_{GetHostPlatformName()}_{GetHostArchitectureName()}.zip");
+                var serverPackage = Path.Combine(_repoPath, "release", $"SS14.Server_{serverPlatform}.zip");
 
                 await using var stream = File.Open(serverPackage, FileMode.Open);
 
@@ -192,15 +291,16 @@ namespace SS14.Watchdog.Components.Updates
                 {
                     Download = new Uri(binariesRoot, ClientZipName).ToString(),
                     Hash = GetFileHash(Path.Combine(binariesPath, ClientZipName)),
-                    Version = localBranch.Tip.ToString(),
-                    EngineVersion = engineVersion,
+                    Version = actualConfirmedHead,
+                    // Use ACZ version auto-detection.
+                    EngineVersion = "",
                     ForkId = _baseUrl,
                 };
 
                 await File.WriteAllTextAsync(Path.Combine(binPath, "build.json"), JsonSerializer.Serialize(build), cancel);
                 
                 // ReSharper disable once RedundantTypeArgumentsOfMethod
-                return localBranch.Tip.ToString();
+                return actualConfirmedHead;
             }
             catch (Exception e)
             {
@@ -213,38 +313,19 @@ namespace SS14.Watchdog.Components.Updates
         private class Build
         {
             [JsonPropertyName("download")]
-            public string Download { get; set; }
+            public string Download { get; set; } = default!;
             
             [JsonPropertyName("hash")]
-            public string Hash { get; set; }
+            public string Hash { get; set; } = default!;
             
             [JsonPropertyName("version")]
-            public string Version { get; set; }
+            public string Version { get; set; } = default!;
             
             [JsonPropertyName("engine_version")]
-            public string EngineVersion { get; set; }
+            public string EngineVersion { get; set; } = default!;
             
             [JsonPropertyName("fork_id")]
-            public string ForkId { get; set; }
-        }
-        
-        private async Task TryClone(CancellationToken cancel = default)
-        {
-            _logger.LogTrace("Cloning git repository...");
-            
-            if(Directory.Exists(_repoPath))
-                Directory.Delete(_repoPath, true);
-            
-            await Task.Run(() => Repository.Clone(_baseUrl, _repoPath, new CloneOptions(){RecurseSubmodules = true}), cancel);
-            
-            using var repository = new Repository(_repoPath);
-            var remote = repository.Network.Remotes["origin"];
-            var refSpecs = remote.FetchRefSpecs.Select(x => x.Specification);
-            await Task.Run(() => Commands.Fetch(repository, remote.Name, refSpecs, null, null), cancel);
-            var remoteBranch = repository.Branches[$"origin/{_branch}"];
-            var localBranch = repository.Branches.Any(x => x.FriendlyName == _branch) 
-                ? repository.Branches[_branch] : repository.CreateBranch(_branch);
-            repository.Branches.Update(localBranch, b => b.TrackedBranch = remoteBranch.CanonicalName);
+            public string ForkId { get; set; } = default!;
         }
     }
 }

--- a/SS14.Watchdog/Components/Updates/UpdateProviderJenkins.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderJenkins.cs
@@ -85,7 +85,7 @@ namespace SS14.Watchdog.Components.Updates
                 // Create temporary file to download binary into (not doing this in memory).
                 await using var tempFile = TempFile.CreateTempFile();
                 // Download URI for server binary.
-                var serverDownload = new Uri(downloadRootUri, $"SS14.Server_{GetHostPlatformName()}_{GetHostArchitectureName()}.zip");
+                var serverDownload = new Uri(downloadRootUri, ServerZipName);
 
                 _logger.LogTrace("Downloading server binary from {download} to {tempFile}", serverDownload,
                     tempFile.Name);

--- a/SS14.Watchdog/Configuration/Updates/UpdateProviderGitConfiguration.cs
+++ b/SS14.Watchdog/Configuration/Updates/UpdateProviderGitConfiguration.cs
@@ -2,7 +2,11 @@ namespace SS14.Watchdog.Configuration.Updates
 {
     public class UpdateProviderGitConfiguration
     {
+        /// <summary> Git repository URL. Not to be confused with the other BaseUrl. </summary>
         public string BaseUrl { get; set; } = null!;
+        /// <summary> Git repository branch. </summary>
         public string Branch { get; set; } = "master";
+        /// <summary> Hybrid ACZ hosts the client zip on the status host for easier port forwarding (no need to forward the watchdog port). </summary>
+        public bool HybridACZ { get; set; } = true;
     }
 }

--- a/SS14.Watchdog/SS14.Watchdog.csproj
+++ b/SS14.Watchdog/SS14.Watchdog.csproj
@@ -10,7 +10,6 @@
       <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" />
       <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.251802" />
       <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-      <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
       <PackageReference Include="NetEscapades.Configuration.Yaml" Version="2.0.1" />
       <PackageReference Include="Serilog" Version="2.10.0" />
       <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />

--- a/SS14.Watchdog/appsettings.Development.yml
+++ b/SS14.Watchdog/appsettings.Development.yml
@@ -36,6 +36,13 @@ Servers:
       #Updates:
       #  BaseUrl: "https://github.com/space-wizards/space-station-14.git"
       #  Branch: "master"
+      #  HybridACZ: true
+
+      #UpdateType: "Git"
+      #Updates:
+      #  BaseUrl: "https://github.com/space-wizards/space-station-14.git"
+      #  Branch: "master"
+      #  HybridACZ: false
 
       #UpdateType: "Jenkins"
       #Updates:

--- a/SS14.Watchdog/appsettings.yml
+++ b/SS14.Watchdog/appsettings.yml
@@ -19,4 +19,7 @@ Serilog:
   #  Address: "http://localhost:3100"
   #  Name: "Test"
 
+# Important if using Git update method
+# BaseUrl: "http://localhost:5000/"
+
 AllowedHosts: "*"


### PR DESCRIPTION
+ Removes libgit2sharp completely in favour of command invocations.
+ Not tested on Windows - someone *should* probably do this
+ Tested for the "everything goes well" situation. I need to figure out what to do about other cases.
+ Will nuke the repository from orbit if updating is not possible - this also means it is capable of surviving even entire repository recreation.
+ Uses `--depth=1` for bandwidth reduction.