### PR TITLE
Add S3 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on: 
+  push:
+    branches: [ master ]
+
+jobs:
+  release-on-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup .NET 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+      - name: Build
+        run: dotnet publish -c Release -r linux-x64 --no-self-contained
+      - name: Zip
+        uses: montudor/action-zip@v1.0.0
+        with:
+          args: zip -qq -j -r latest.zip /github/workspace/SS14.Watchdog/bin/Release/net6.0/linux-x64/publish/
+      - name: Release to Bucket
+        uses: koraykoska/s3-upload-github-action@master
+        env:
+          FILE: latest.zip
+          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          S3_PREFIX: 'builds'

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 SS14.Watchdog (codename Ian) is SS14's server-hosting wrapper thing, similar to [TGS](https://github.com/tgstation/tgstation-server) for BYOND (but much simpler for the time being). It handles auto updates, monitoring, automatic restarts, and administration. We recommend you use this for proper deployments.
 
 Documentation on how setup and use for SS14.Watchdog is [here](https://docs.spacestation14.io/en/getting-started/hosting#ss14watchdog).
+
+## Builds
+The latest linux-x64 `master` build of SS14.Watchdog is available at https://ss14-watchdog.s3.us-west-000.backblazeb2.com/builds/latest.zip.


### PR DESCRIPTION
Adds a workflow that publishes the latest linux build of watchdog to an s3 bucket configured with GitHub secrets.

Example use-case is an installation script for containers that requires a built version.