### PR TITLE
Create dummy config file for servers where none found

### DIFF
--- a/SS14.Watchdog/Components/ServerManagement/ServerInstance.cs
+++ b/SS14.Watchdog/Components/ServerManagement/ServerInstance.cs
@@ -253,6 +253,14 @@ namespace SS14.Watchdog.Components.ServerManagement
 
             _logger.LogTrace("Getting launch info...");
 
+            var configFile = Path.Combine(InstanceDir, "config.toml");
+
+            if (!File.Exists(configFile))
+            {
+                _logger.LogInformation("No config.toml found, creating one at {configFile}", configFile);
+                File.Create(configFile);
+            }
+
             var startInfo = new ProcessStartInfo
             {
                 WorkingDirectory = InstanceDir,
@@ -265,7 +273,7 @@ namespace SS14.Watchdog.Components.ServerManagement
                     "--cvar", $"watchdog.key={Key}",
                     "--cvar", $"watchdog.baseUrl={_configuration["BaseUrl"]}",
 
-                    "--config-file", Path.Combine(InstanceDir, "config.toml"),
+                    "--config-file", configFile,
                     "--data-dir", Path.Combine(InstanceDir, "data"),
                 }
             };


### PR DESCRIPTION
Please let me know if this solution is shit.

Pros:
- More noob friendly because if they want to touch the config it actually exists.
- Launching Watchdog from scratch no longer crashes.
Cons:
- Should server just do this or should it continue to throw if no config.toml exists (I assume yes?)

Resolves https://github.com/space-wizards/SS14.Watchdog/issues/15