### PR TITLE
Launch arguments feature

### DIFF
--- a/SS14.Watchdog/Components/ServerManagement/ServerInstance.Actor.cs
+++ b/SS14.Watchdog/Components/ServerManagement/ServerInstance.Actor.cs
@@ -335,9 +335,14 @@ public sealed partial class ServerInstance
 
             "--config-file", Path.Combine(InstanceDir, "config.toml"),
             "--data-dir", Path.Combine(InstanceDir, "data"),
-
-            $"{_instanceConfig.Arguments}"
         };
+
+        // Prepare the user provided arguments
+        foreach (var arg in _instanceConfig.Arguments)
+        {
+            args.Add(arg);
+        }
+
         var env = new List<(string, string)>();
 
         foreach (var (envVar, value) in _instanceConfig.EnvironmentVariables)

--- a/SS14.Watchdog/Components/ServerManagement/ServerInstance.Actor.cs
+++ b/SS14.Watchdog/Components/ServerManagement/ServerInstance.Actor.cs
@@ -335,6 +335,8 @@ public sealed partial class ServerInstance
 
             "--config-file", Path.Combine(InstanceDir, "config.toml"),
             "--data-dir", Path.Combine(InstanceDir, "data"),
+
+            $"{_instanceConfig.Arguments}"
         };
         var env = new List<(string, string)>();
 

--- a/SS14.Watchdog/Configuration/InstanceConfiguration.cs
+++ b/SS14.Watchdog/Configuration/InstanceConfiguration.cs
@@ -23,6 +23,11 @@ namespace SS14.Watchdog.Configuration
             : "bin/Robust.Server";
 
         /// <summary>
+        ///     User arguments to pass to the server process.
+        /// </summary>
+        public string Arguments { get; set; } = null!;
+
+        /// <summary>
         /// Make a heap dump if the server is killed due to timeout. Only supported on Linux.
         /// </summary>
         public bool DumpOnTimeout { get; set; } = true;

--- a/SS14.Watchdog/Configuration/InstanceConfiguration.cs
+++ b/SS14.Watchdog/Configuration/InstanceConfiguration.cs
@@ -25,7 +25,7 @@ namespace SS14.Watchdog.Configuration
         /// <summary>
         ///     User arguments to pass to the server process.
         /// </summary>
-        public string Arguments { get; set; } = null!;
+        public List<string> Arguments { get; set; } = [];
 
         /// <summary>
         /// Make a heap dump if the server is killed due to timeout. Only supported on Linux.


### PR DESCRIPTION
I wanted to delay round start only for the first server start but i found another bug in content... may as well commit this for anyone who needs it and when i fix it

![image](https://github.com/space-wizards/SS14.Watchdog/assets/34938708/856bc95f-de61-453e-8808-f54674bc4c30)
![image](https://github.com/space-wizards/SS14.Watchdog/assets/34938708/0dcba8ee-2a43-4fdb-9e6c-be6345224dc8)
![image](https://github.com/space-wizards/SS14.Watchdog/assets/34938708/d2566a21-3eba-4dae-8499-87e2ca4fd4e4)
