### PR TITLE
Copy SECURITY.md from space-wizards/space-station-14

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Reporting a security vulnerability
+You can report a security vulnerability through Discord or through email.
+
+If you want to send an email, you can contact us at <telecommunications@spacestation14.com>.
+If you want to contact us through Discord, you can join [our server](https://discord.gg/MwDDf6t)
+and then **privately** message anyone with the `@Wizard` or `@SS14 Maintainer` role.
+
+In either case, **do not publicly disclose the vulnerability until we explicitly give
+you permission to do so**.


### PR DESCRIPTION
Stumbled across the absence of the security reporting policy on this repository when I came across #27 . Having one, even if copied, is better than not having one at all.