### PR TITLE
Pass Watchdog token via environment variable

### DIFF
--- a/SS14.Watchdog/Components/ServerManagement/ServerInstance.Actor.cs
+++ b/SS14.Watchdog/Components/ServerManagement/ServerInstance.Actor.cs
@@ -329,9 +329,10 @@ public sealed partial class ServerInstance
         var args = new List<string>
         {
             // Watchdog comms config.
-            "--cvar", $"watchdog.token={Secret}",
             "--cvar", $"watchdog.key={Key}",
             "--cvar", $"watchdog.baseUrl={_baseServerAddress}",
+            // watchdog.token provided through ENV vars, as this does not show up in process listings
+            // like `ps -aux` or `htop`.
 
             "--config-file", Path.Combine(InstanceDir, "config.toml"),
             "--data-dir", Path.Combine(InstanceDir, "data"),
@@ -343,7 +344,11 @@ public sealed partial class ServerInstance
             args.Add(arg);
         }
 
-        var env = new List<(string, string)>();
+        var env = new List<(string, string)>
+        {
+            // __ is replaced by a . when parsing CVars from an environment variable.
+            ("ROBUST_CVAR_watchdog__token", $"{Secret}")
+        };
 
         foreach (var (envVar, value) in _instanceConfig.EnvironmentVariables)
         {


### PR DESCRIPTION
Closes #27 .

Necessary as command line arguments, through which this was originally passed, show up in process listings on the host. Environment variables are generally the preferred way of passing secrets to processes.

RobustToolbox supports this syntax as of the 4th of April 2024 with commit 84360c653d26baa4ce7510d8d1b003ea617aa02b . This PR does form a **breaking change** for use cases where older versions of RobustToolbox are required, and this should be communicated accordingly if deemed relevant.