### PR TITLE
Add basic Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /build
+COPY *.sln .
+COPY SS14.Watchdog/. ./SS14.Watchdog/
+COPY SS14.Watchdog.Tests/. ./SS14.Watchdog.Tests/
+
+RUN dotnet publish -c Release -r linux-x64 --no-self-contained -o /publish
+RUN dotnet test
+
+FROM build AS dev
+WORKDIR /watchdog
+COPY --from=build /publish .
+RUN chmod +x ./SS14.Watchdog
+CMD ["./SS14.Watchdog"]
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /watchdog
+COPY --from=build /publish .
+RUN chmod +x ./SS14.Watchdog
+CMD ["./SS14.Watchdog"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,32 @@
+x-watchdog-base: &watchdog-base
+  build:
+    context: .
+  environment:
+    - ASPNETCORE_URLS=${WATCHDOG_URL}
+  ports:
+    - ${WATCHDOG_PORT}:${WATCHDOG_PORT}
+    - ${SS14_PORT}:${SS14_PORT}/tcp
+    - ${SS14_PORT}:${SS14_PORT}/udp
+  restart: unless-stopped
+  volumes:
+    - ./instances:/watchdog/instances
+    - ./SS14.Watchdog/appsettings.yml:/watchdog/appsettings.yml
+
+services:
+  watchdog:
+    <<: *watchdog-base
+    container_name: ss14-watchdog
+    build:
+      context: .
+      target: runtime
+    profiles:
+      - prod
+
+  watchdog-dev:
+    <<: *watchdog-base
+    container_name: ss14-watchdog-dev
+    build:
+      context: .
+      target: dev
+    profiles:
+      - dev


### PR DESCRIPTION
This PR introduces a basic containerization support with two profiles: **dev** and **prod**

**Dev**: Heavier image that uses the full SDK for both build and runtime. This is ideal if you plan to use the [Git-based update method](https://docs.spacestation14.com/en/server-hosting/setting-up-ss14-watchdog.html#git-based-updates)

**Prod**: Lightweight image that uses the ASP.NET runtime. This is ideal for production environments using the [manifest update method](https://docs.spacestation14.com/en/server-hosting/setting-up-ss14-watchdog.html#manifest-update)

Before running the container, ensure you have a .env file in the root directory with the following variables defined:
```env
SS14_PORT
WATCHDOG_PORT
WATCHDOG_URL
```

to run the container execute the following command:
```bash
docker compose --profile <dev|prod> up
```
