### PR TITLE
Use graceful shutdown wait timeout

### DIFF
--- a/SS14.Watchdog/Components/ServerManagement/ServerInstance.cs
+++ b/SS14.Watchdog/Components/ServerManagement/ServerInstance.cs
@@ -402,7 +402,7 @@ namespace SS14.Watchdog.Components.ServerManagement
             ProcessExitStatus? status;
             try
             {
-                await proc.WaitForExitAsync(cancel);
+                await proc.WaitForExitAsync(waitCts.Token);
                 status = await proc.GetExitStatusAsync();
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
This is made but never used.

The call above this (line 379) creates its own shutdown token as well similarly but actually uses it.