### PR TITLE
Fix malformed auth headers + tests

### DIFF
--- a/SS14.Watchdog.Tests/Controllers/ServerApiControllerTest.cs
+++ b/SS14.Watchdog.Tests/Controllers/ServerApiControllerTest.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NUnit.Framework;
 using SS14.Watchdog.Components.ServerManagement;
@@ -56,9 +58,61 @@ namespace SS14.Watchdog.Tests.Controllers
         }
 
         [Test]
-        public void TestPing()
+        public void TestAuthorizationMissingHeader()
         {
+            // Arrange
+            var manager = Mock.Of<IServerManager>();
+            var controller = new ServerApiController(manager);
 
+            // Act
+            var success = controller.TryAuthorize(null!, "honk", out var failure, out var instance);
+
+            // Assert
+            Assert.That(success, Is.False);
+            Assert.That(failure, Is.InstanceOf<UnauthorizedResult>());
+            Assert.That(instance, Is.Null);
+        }
+
+        [Test]
+        public void TestAuthorizationInvalidBase64()
+        {
+            // Arrange
+            var manager = Mock.Of<IServerManager>();
+            var controller = new ServerApiController(manager);
+
+            // Act
+            var success = controller.TryAuthorize("Basic definitely not base64", "honk", out var failure, out var instance);
+
+            // Assert
+            Assert.That(success, Is.False);
+            Assert.That(failure, Is.InstanceOf<BadRequestResult>());
+            Assert.That(instance, Is.Null);
+        }
+
+        [Test]
+        public async Task TestPing()
+        {
+            // Arrange
+            const string secret = "secure that disk";
+            const string key = "foo";
+
+            var instanceMock = new Mock<IServerInstance>();
+            instanceMock.SetupGet(p => p.Secret).Returns(secret);
+            instanceMock.SetupGet(p => p.Key).Returns(key);
+
+            var instance = instanceMock.Object;
+            var manager = new Mock<IServerManager>();
+            manager.Setup(i => i.TryGetInstance(key, out instance)).Returns(true);
+
+            var controller = new ServerApiController(manager.Object);
+            var authCorrect = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{key}:{secret}"));
+
+            // Act
+            var response = await controller.PingAsync(authCorrect, key);
+
+            // Assert
+            Assert.That(response, Is.InstanceOf<OkResult>());
+            instanceMock.Verify(i => i.PingReceived(), Times.Once);
         }
     }
 }

--- a/SS14.Watchdog.Tests/Controllers/ServerApiControllerTest.cs
+++ b/SS14.Watchdog.Tests/Controllers/ServerApiControllerTest.cs
@@ -7,112 +7,111 @@ using NUnit.Framework;
 using SS14.Watchdog.Components.ServerManagement;
 using SS14.Watchdog.Controllers;
 
-namespace SS14.Watchdog.Tests.Controllers
+namespace SS14.Watchdog.Tests.Controllers;
+
+public class ServerApiControllerTest
 {
-    public class ServerApiControllerTest
+    [Test]
+    public void TestAuthorizationSuccess()
     {
-        [Test]
-        public void TestAuthorizationSuccess()
-        {
-            // Arrange
-            const string secret = "Secure that disk!";
-            const string key = "foo";
+        // Arrange
+        const string secret = "Secure that disk!";
+        const string key = "foo";
 
-            var instanceMock = new Mock<IServerInstance>();
-            instanceMock.SetupGet(p => p.Secret).Returns(secret);
-            instanceMock.SetupGet(p => p.Key).Returns(key);
+        var instanceMock = new Mock<IServerInstance>();
+        instanceMock.SetupGet(p => p.Secret).Returns(secret);
+        instanceMock.SetupGet(p => p.Key).Returns(key);
 
-            var instance = instanceMock.Object;
-            var manager = new Mock<IServerManager>();
-            manager.Setup(i => i.TryGetInstance(key, out instance)).Returns(true);
+        var instance = instanceMock.Object;
+        var manager = new Mock<IServerManager>();
+        manager.Setup(i => i.TryGetInstance(key, out instance)).Returns(true);
 
-            var controller = new ServerApiController(manager.Object);
+        var controller = new ServerApiController(manager.Object);
 
-            var authCorrect = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{key}:{secret}"));
-            var authWrong = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{key}:oof"));
+        var authCorrect = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{key}:{secret}"));
+        var authWrong = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{key}:oof"));
 
-            // Act
-            var success = controller.TryAuthorize(authCorrect, key, out var noFailure, out var correctInstance);
-            var expectFail = controller.TryAuthorize(authWrong, key, out var failure, out var failInstance);
+        // Act
+        var success = controller.TryAuthorize(authCorrect, key, out var noFailure, out var correctInstance);
+        var expectFail = controller.TryAuthorize(authWrong, key, out var failure, out var failInstance);
 
-            // Assert
-            Assert.That(success);
-            Assert.That(correctInstance, Is.EqualTo(instanceMock.Object));
+        // Assert
+        Assert.That(success);
+        Assert.That(correctInstance, Is.EqualTo(instanceMock.Object));
 
-            Assert.That(expectFail, Is.False);
-            Assert.That(failure, Is.Not.Null);
-        }
+        Assert.That(expectFail, Is.False);
+        Assert.That(failure, Is.Not.Null);
+    }
 
-        [Test]
-        public void TestAuthorizationMalformed()
-        {
-            // Arrange
-            var manager = Mock.Of<IServerManager>();
-            var controller = new ServerApiController(manager);
+    [Test]
+    public void TestAuthorizationMalformed()
+    {
+        // Arrange
+        var manager = Mock.Of<IServerManager>();
+        var controller = new ServerApiController(manager);
 
-            // Act
-            var success = controller.TryAuthorize("Foobar", "honk", out var failure, out var instance);
+        // Act
+        var success = controller.TryAuthorize("Foobar", "honk", out var failure, out var instance);
 
-            // Assert
-            Assert.That(success, Is.False);
-        }
+        // Assert
+        Assert.That(success, Is.False);
+    }
 
-        [Test]
-        public void TestAuthorizationMissingHeader()
-        {
-            // Arrange
-            var manager = Mock.Of<IServerManager>();
-            var controller = new ServerApiController(manager);
+    [Test]
+    public void TestAuthorizationMissingHeader()
+    {
+        // Arrange
+        var manager = Mock.Of<IServerManager>();
+        var controller = new ServerApiController(manager);
 
-            // Act
-            var success = controller.TryAuthorize(null!, "honk", out var failure, out var instance);
+        // Act
+        var success = controller.TryAuthorize(null!, "honk", out var failure, out var instance);
 
-            // Assert
-            Assert.That(success, Is.False);
-            Assert.That(failure, Is.InstanceOf<UnauthorizedResult>());
-            Assert.That(instance, Is.Null);
-        }
+        // Assert
+        Assert.That(success, Is.False);
+        Assert.That(failure, Is.InstanceOf<UnauthorizedResult>());
+        Assert.That(instance, Is.Null);
+    }
 
-        [Test]
-        public void TestAuthorizationInvalidBase64()
-        {
-            // Arrange
-            var manager = Mock.Of<IServerManager>();
-            var controller = new ServerApiController(manager);
+    [Test]
+    public void TestAuthorizationInvalidBase64()
+    {
+        // Arrange
+        var manager = Mock.Of<IServerManager>();
+        var controller = new ServerApiController(manager);
 
-            // Act
-            var success = controller.TryAuthorize("Basic definitely not base64", "honk", out var failure, out var instance);
+        // Act
+        var success = controller.TryAuthorize("Basic definitely not base64", "honk", out var failure, out var instance);
 
-            // Assert
-            Assert.That(success, Is.False);
-            Assert.That(failure, Is.InstanceOf<BadRequestResult>());
-            Assert.That(instance, Is.Null);
-        }
+        // Assert
+        Assert.That(success, Is.False);
+        Assert.That(failure, Is.InstanceOf<BadRequestResult>());
+        Assert.That(instance, Is.Null);
+    }
 
-        [Test]
-        public async Task TestPing()
-        {
-            // Arrange
-            const string secret = "Secure that disk!";
-            const string key = "foo";
+    [Test]
+    public async Task TestPing()
+    {
+        // Arrange
+        const string secret = "Secure that disk!";
+        const string key = "foo";
 
-            var instanceMock = new Mock<IServerInstance>();
-            instanceMock.SetupGet(p => p.Secret).Returns(secret);
-            instanceMock.SetupGet(p => p.Key).Returns(key);
+        var instanceMock = new Mock<IServerInstance>();
+        instanceMock.SetupGet(p => p.Secret).Returns(secret);
+        instanceMock.SetupGet(p => p.Key).Returns(key);
 
-            var instance = instanceMock.Object;
-            var manager = new Mock<IServerManager>();
-            manager.Setup(i => i.TryGetInstance(key, out instance)).Returns(true);
+        var instance = instanceMock.Object;
+        var manager = new Mock<IServerManager>();
+        manager.Setup(i => i.TryGetInstance(key, out instance)).Returns(true);
 
-            var controller = new ServerApiController(manager.Object);
-            var authCorrect = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{key}:{secret}"));
+        var controller = new ServerApiController(manager.Object);
+        var authCorrect = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{key}:{secret}"));
 
-            // Act
-            var response = await controller.PingAsync(authCorrect, key);
+        // Act
+        var response = await controller.PingAsync(authCorrect, key);
 
-            // Assert
-            Assert.That(response, Is.InstanceOf<OkResult>());
-            instanceMock.Verify(i => i.PingReceived(), Times.Once);
-        }
+        // Assert
+        Assert.That(response, Is.InstanceOf<OkResult>());
+        instanceMock.Verify(i => i.PingReceived(), Times.Once);
     }
 }

--- a/SS14.Watchdog.Tests/Controllers/ServerApiControllerTest.cs
+++ b/SS14.Watchdog.Tests/Controllers/ServerApiControllerTest.cs
@@ -15,7 +15,7 @@ namespace SS14.Watchdog.Tests.Controllers
         public void TestAuthorizationSuccess()
         {
             // Arrange
-            const string secret = "secure that disk";
+            const string secret = "Secure that disk!";
             const string key = "foo";
 
             var instanceMock = new Mock<IServerInstance>();
@@ -93,7 +93,7 @@ namespace SS14.Watchdog.Tests.Controllers
         public async Task TestPing()
         {
             // Arrange
-            const string secret = "secure that disk";
+            const string secret = "Secure that disk!";
             const string key = "foo";
 
             var instanceMock = new Mock<IServerInstance>();

--- a/SS14.Watchdog/Utility/AuthorizationUtility.cs
+++ b/SS14.Watchdog/Utility/AuthorizationUtility.cs
@@ -6,7 +6,7 @@ namespace SS14.Watchdog.Utility
 {
     public static class AuthorizationUtility
     {
-        public static bool TryParseBasicAuthentication(string? authorization,
+        public static bool TryParseBasicAuthentication(string authorization,
             [NotNullWhen(false)] out IActionResult? failure,
             [NotNullWhen(true)] out string? username,
             [NotNullWhen(true)] out string? password)
@@ -14,7 +14,7 @@ namespace SS14.Watchdog.Utility
             username = null;
             password = null;
 
-            if (authorization == null || !authorization.StartsWith("Basic "))
+            if (!authorization.StartsWith("Basic "))
             {
                 failure = new UnauthorizedResult();
                 return false;

--- a/SS14.Watchdog/Utility/AuthorizationUtility.cs
+++ b/SS14.Watchdog/Utility/AuthorizationUtility.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Mvc;
 
@@ -5,7 +6,7 @@ namespace SS14.Watchdog.Utility
 {
     public static class AuthorizationUtility
     {
-        public static bool TryParseBasicAuthentication(string authorization,
+        public static bool TryParseBasicAuthentication(string? authorization,
             [NotNullWhen(false)] out IActionResult? failure,
             [NotNullWhen(true)] out string? username,
             [NotNullWhen(true)] out string? password)
@@ -13,13 +14,24 @@ namespace SS14.Watchdog.Utility
             username = null;
             password = null;
 
-            if (!authorization.StartsWith("Basic "))
+            if (authorization == null || !authorization.StartsWith("Basic "))
             {
                 failure = new UnauthorizedResult();
                 return false;
             }
 
-            var split = Base64Util.Utf8Base64ToString(authorization[6..]).Split(':');
+            string decoded;
+            try
+            {
+                decoded = Base64Util.Utf8Base64ToString(authorization[6..]);
+            }
+            catch (FormatException)
+            {
+                failure = new BadRequestResult();
+                return false;
+            }
+
+            var split = decoded.Split(':');
 
             if (split.Length != 2)
             {

--- a/SS14.Watchdog/Utility/AuthorizationUtility.cs
+++ b/SS14.Watchdog/Utility/AuthorizationUtility.cs
@@ -6,7 +6,7 @@ namespace SS14.Watchdog.Utility
 {
     public static class AuthorizationUtility
     {
-        public static bool TryParseBasicAuthentication(string authorization,
+        public static bool TryParseBasicAuthentication(string? authorization,
             [NotNullWhen(false)] out IActionResult? failure,
             [NotNullWhen(true)] out string? username,
             [NotNullWhen(true)] out string? password)
@@ -14,7 +14,7 @@ namespace SS14.Watchdog.Utility
             username = null;
             password = null;
 
-            if (!authorization.StartsWith("Basic "))
+            if (authorization == null || !authorization.StartsWith("Basic "))
             {
                 failure = new UnauthorizedResult();
                 return false;


### PR DESCRIPTION
Malformed + missing would fail on master (due to null / malformed just throwing) so this hopefully fixes them.