### PR TITLE
Super Simple 14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 appsettings.Secret.yml
 SS14.Watchdog/data.db
 SS14.Watchdog/data.db-journal
+instances/
+SS14.Watchdog/instances/
+SS14.Watchdog/bin/instances/
 
 
 # Created by https://www.gitignore.io/api/csharp

--- a/.run/SS14.Watchdog Development.run.xml
+++ b/.run/SS14.Watchdog Development.run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="SS14.Watchdog Development" type="DotNetProject" factoryName=".NET Project">
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/SS14.Watchdog/SS14.Watchdog.csproj" />
+    <option name="PROJECT_TFM" value="net10.0" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/SS14.Watchdog" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <envs>
+      <env name="ASPNETCORE_ENVIRONMENT" value="Development" />
+      <env name="DOTNET_ENVIRONMENT" value="Development" />
+      <env name="ASPNETCORE_URLS" value="https://localhost:5001;http://localhost:5000" />
+    </envs>
+    <method v="2">
+      <option name="Build" />
+    </method>
+  </configuration>
+</component>

--- a/.run/SS14.Watchdog Local.run.xml
+++ b/.run/SS14.Watchdog Local.run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="SS14.Watchdog Local" type="DotNetProject" factoryName=".NET Project">
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/SS14.Watchdog/SS14.Watchdog.csproj" />
+    <option name="PROJECT_TFM" value="net10.0" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/SS14.Watchdog" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <envs>
+      <env name="ASPNETCORE_ENVIRONMENT" value="Local" />
+      <env name="DOTNET_ENVIRONMENT" value="Local" />
+      <env name="ASPNETCORE_URLS" value="https://localhost:5001;http://localhost:5000" />
+    </envs>
+    <method v="2">
+      <option name="Build" />
+    </method>
+  </configuration>
+</component>

--- a/.run/SS14.Watchdog Starter.run.xml
+++ b/.run/SS14.Watchdog Starter.run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="SS14.Watchdog Starter" type="DotNetProject" factoryName=".NET Project">
+    <option name="PROJECT_PATH" value="$PROJECT_DIR$/SS14.Watchdog/SS14.Watchdog.csproj" />
+    <option name="PROJECT_TFM" value="net10.0" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/SS14.Watchdog" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <option name="USE_EXTERNAL_CONSOLE" value="0" />
+    <envs>
+      <env name="ASPNETCORE_ENVIRONMENT" value="Starter" />
+      <env name="DOTNET_ENVIRONMENT" value="Starter" />
+      <env name="ASPNETCORE_URLS" value="https://localhost:5001;http://localhost:5000" />
+    </envs>
+    <method v="2">
+      <option name="Build" />
+    </method>
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 SS14.Watchdog is SS14's server-hosting wrapper thing, similar to [TGS](https://github.com/tgstation/tgstation-server) for BYOND (but much simpler for the time being). It handles auto updates, monitoring, automatic restarts, and administration. We recommend you use this for proper deployments.
 
+If you wish to setup a server for long-term consult the [long-term hosting](#long-term-hosting) section before continuing.
+
+For the verbose guide see [the docs wiki](http://docs.spacestation14.com/en/server-hosting/setting-up-ss14-watchdog.html)
+
 ## Local server
 
 `appsettings.yml` is intentionally minimal and mostly a dummy/default config.
@@ -22,7 +26,7 @@ Then start Watchdog with one of the starter scripts:
 The starter config uses the `Git` update provider. The starter script will clone the target repository into SS14.Watchdog/instances/\<instance_name>
 
 After it has run once you will see a config.toml that you can adjust to set the CVars to your liking.
-For the full list of available CVars you will need to browse the development repository of your target server. Look for CCVars and CVars with Server flags.
+For the full list of available CVars you will need to browse the development repository of your target server. Look for [CCVars](https://github.com/space-wizards/space-station-14/tree/master/Content.Shared/CCVar) and [CVars](https://github.com/space-wizards/RobustToolbox/blob/master/Robust.Shared/CVars.cs) with Server flags.
 
 Per-instance watchdog logs are written to `logs/<instance>/watchdog-*.log`.
 
@@ -35,7 +39,7 @@ If an update is available, Watchdog tells the game server to shut down, applies 
 
 ## Update providers
 
-Each server instance chooses its own update provider with `Servers:Instances:<key>:UpdateType` and an optional `Updates` section. Different instances can use different providers.
+Each server instance chooses its own update provider with `Servers:Instances:<key>:UpdateType` and an optional `Updates` section. Different instances can use different providers. This is useful if you wish to host different forks with the same watchdog; Robust.Cdn supports this configuration.
 
 ### Manifest
 
@@ -132,6 +136,10 @@ Use `Dummy` only for tests or manual experiments. It always reports an update an
 
 ## Long-term hosting
 
-For long-term public hosting, prefer a release pipeline that publishes builds and use `Manifest` updates instead of building from `Git` on the host. See https://github.com/space-wizards/Robust.Cdn for manifest hosting.
+For long-term public hosting, prefer a release pipeline that publishes builds and use `Manifest` updates instead of building from `Git` on the host.
+- See https://github.com/space-wizards/Robust.Cdn for manifest hosting.
+- See Content.Packaging on https://github.com/space-wizards/space-station-14 for building the client manifests.
 
 Use a real database for production game server data. The generated starter `config.toml` defaults are suitable for getting a server running, but public or persistent servers should configure PostgreSQL in `config.toml` instead of relying on local SQLite files.
+
+Note that there is no easy way to convert SQLite files to Postgres and you risk data-loss if you try.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,6 @@ Use `Dummy` only for tests or manual experiments. It always reports an update an
 
 ## Long-term hosting
 
-For long-term public hosting, prefer a release pipeline that publishes builds and use `Manifest` updates instead of building from `Git` on the host.
+For long-term public hosting, prefer a release pipeline that publishes builds and use `Manifest` updates instead of building from `Git` on the host. See https://github.com/space-wizards/Robust.Cdn for manifest hosting.
 
 Use a real database for production game server data. The generated starter `config.toml` defaults are suitable for getting a server running, but public or persistent servers should configure PostgreSQL in `config.toml` instead of relying on local SQLite files.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,139 @@
-# SS14.Watchdog 
+# SS14.Watchdog
 
 SS14.Watchdog is SS14's server-hosting wrapper thing, similar to [TGS](https://github.com/tgstation/tgstation-server) for BYOND (but much simpler for the time being). It handles auto updates, monitoring, automatic restarts, and administration. We recommend you use this for proper deployments.
 
-Documentation on how setup and use for SS14.Watchdog is [here](https://docs.spacestation14.io/en/getting-started/hosting#watchdog).
+## Local server
+
+`appsettings.yml` is intentionally minimal and mostly a dummy/default config.
+
+For local hosting tests against a locally built game server, set `ASPNETCORE_ENVIRONMENT=Local` to load `appsettings.Local.yml`.
+The local config uses `bin/instances` and the `Local` update provider.
+
+## Starter server
+
+The starter config uses the `Git` update provider; replace the API token, server name, branch, and set advertise=true as needed before hosting publicly.
+
+Before running a starter server for the first time, open `SS14.Watchdog/appsettings.Starter.yml`, read the comments, and update the placeholder values.
+
+Then start Watchdog with one of the starter scripts:
+
+- Windows Command Prompt: `run-starter.bat`
+- PowerShell: `./run-starter.ps1`
+- Bash: `./run-starter.sh`
+
+The starter script will clone the target repository into SS14.Watchdog/instances/\<instance_name>
+
+Note that the instance_name is not the server name, it is just your name to refer to it. To update the server name set hostname in config.toml
+
+After it has run once you will see a config.toml that you can adjust to set the CVars to your liking.
+For the full list of available CVars you will need to browse the development repository of your target server.
+
+Per-instance watchdog logs are written to `logs/<instance>/watchdog-*.log`.
+
+## Update checks
+
+Watchdog update checks are normally triggered by the game server between rounds. When the server reports that it is safe to update, Watchdog asks the configured update provider whether a newer version exists.
+If an update is available, Watchdog tells the game server to shut down, applies the update after it exits, and relaunches the instance.
+
+## Update providers
+
+Each server instance chooses its own update provider with `Servers:Instances:<key>:UpdateType` and an optional `Updates` section. Different instances can use different providers.
+
+### Manifest
+
+Use `Manifest` when your publishing pipeline produces an SS14-style manifest. Watchdog fetches the manifest, chooses the newest build, validates, and applies it. This is recommended for long-term hosting.
+
+Properties:
+
+| Property | Required | Description |
+| --- | --- | --- |
+| `ManifestUrl` | Yes | URL of the SS14 build manifest JSON. |
+| `Authentication` | No | Basic auth credentials used when fetching the manifest and referenced artifacts. |
+| `Authentication:Username` | No | Basic auth username. |
+| `Authentication:Password` | No | Basic auth password. |
+
+```yml
+Servers:
+  Instances:
+    example:
+      UpdateType: Manifest
+      Updates:
+        ManifestUrl: "https://example.com/fork/example/manifest"
+        # Authentication:
+        #   Username: "user"
+        #   Password: "pass"
+```
+
+### Jenkins
+
+Use `Jenkins` for Jenkins publishing. Watchdog reads the job's last successful build and downloads `release/SS14.Server_<rid>.zip` from that build's artifacts.
+
+Properties:
+
+| Property | Required | Description |
+| --- | --- | --- |
+| `BaseUrl` | Yes | Base URL of the Jenkins instance, without the job path. |
+| `JobName` | Yes | Jenkins job name to query for the last successful build. |
+
+```yml
+Servers:
+  Instances:
+    example:
+      UpdateType: Jenkins
+      Updates:
+        BaseUrl: "https://builds.example.com/jenkins"
+        JobName: "SS14 Content"
+```
+
+### Git
+
+Use `Git` for local development or hosts that intentionally build from source on the deployment machine.
+This is not recommended for long-term hosting but can be useful for smaller servers or test branches.
+
+Properties:
+
+| Property | Required | Description |
+| --- | --- | --- |
+| `BaseUrl` | Yes | Git repository URL. This is the source repository URL, not watchdog's root `BaseUrl`. |
+| `Branch` | No | Git branch to fetch, reset to, and package. Defaults to `master`. |
+| `HybridACZ` | No | Builds a hybrid ACZ package when `true`. Defaults to `true`; set `false` when watchdog should host client binaries from `/instances/<key>/binaries`. |
+
+```yml
+Servers:
+  Instances:
+    example:
+      UpdateType: Git
+      Updates:
+        BaseUrl: "https://github.com/space-wizards/space-station-14.git"
+        Branch: "stable"
+        HybridACZ: true
+```
+
+### Local
+
+Use `Local` when something else is managing files in the instance directory. Watchdog only tracks the configured `CurrentVersion`; it does not copy server files.
+
+Properties:
+
+| Property | Required | Description |
+| --- | --- | --- |
+| `CurrentVersion` | Yes | Version string watchdog records as active. Change this after replacing local files externally to make watchdog restart into the new revision. |
+
+```yml
+Servers:
+  Instances:
+    example:
+      UpdateType: Local
+      Updates:
+        CurrentVersion: "local-build-1"
+```
+
+### Dummy
+
+Use `Dummy` only for tests or manual experiments. It always reports an update and advances the recorded revision without copying files.
+
+## Long-term hosting
+
+For long-term public hosting, prefer a release pipeline that publishes builds and use `Manifest` updates instead of building from `Git` on the host.
+
+Use a real database for production game server data. The generated starter `config.toml` defaults are suitable for getting a server running, but public or persistent servers should configure PostgreSQL in `config.toml` instead of relying on local SQLite files.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then start Watchdog with one of the starter scripts:
 The starter config uses the `Git` update provider. The starter script will clone the target repository into SS14.Watchdog/instances/\<instance_name>
 
 After it has run once you will see a config.toml that you can adjust to set the CVars to your liking.
-For the full list of available CVars you will need to browse the development repository of your target server.
+For the full list of available CVars you will need to browse the development repository of your target server. Look for CCVars and CVars with Server flags.
 
 Per-instance watchdog logs are written to `logs/<instance>/watchdog-*.log`.
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ The local config uses `bin/instances` and the `Local` update provider.
 
 ## Starter server
 
-The starter config uses the `Git` update provider; replace the API token, server name, branch, and set advertise=true as needed before hosting publicly.
-
 Before running a starter server for the first time, open `SS14.Watchdog/appsettings.Starter.yml`, read the comments, and update the placeholder values.
 
 Then start Watchdog with one of the starter scripts:
@@ -21,14 +19,14 @@ Then start Watchdog with one of the starter scripts:
 - PowerShell: `./run-starter.ps1`
 - Bash: `./run-starter.sh`
 
-The starter script will clone the target repository into SS14.Watchdog/instances/\<instance_name>
-
-Note that the instance_name is not the server name, it is just your name to refer to it. To update the server name set hostname in config.toml
+The starter config uses the `Git` update provider. The starter script will clone the target repository into SS14.Watchdog/instances/\<instance_name>
 
 After it has run once you will see a config.toml that you can adjust to set the CVars to your liking.
 For the full list of available CVars you will need to browse the development repository of your target server.
 
 Per-instance watchdog logs are written to `logs/<instance>/watchdog-*.log`.
+
+Note that the instance_name is not the server name, it is just your name to refer to it. To update the server name set hostname in config.toml
 
 ## Update checks
 

--- a/SS14.Watchdog/Components/ProcessManagement/ProcessManagerBasic.cs
+++ b/SS14.Watchdog/Components/ProcessManagement/ProcessManagerBasic.cs
@@ -20,6 +20,8 @@ namespace SS14.Watchdog.Components.ProcessManagement;
 /// </remarks>
 public sealed class ProcessManagerBasic : IProcessManager
 {
+    private static readonly object EnvironmentLock = new();
+
     private readonly IOptions<ProcessOptions> _options;
     private readonly ILogger<ProcessManagerBasic> _logger;
     private readonly DataManager _dataManager;
@@ -44,10 +46,33 @@ public sealed class ProcessManagerBasic : IProcessManager
         _logger.LogDebug("Starting game server process for instance {Key}: {Program}", instance.Key, data.Program);
         _logger.LogTrace("Working directory: {WorkingDir}", data.WorkingDirectory);
 
+        var logDirectory = EnsureLogDirectory(instance);
+        var robustLogFile = Path.Combine(logDirectory, "server.log");
+
+        if (_options.Value.LaunchInNewWindow)
+        {
+            _logger.LogInformation(
+                "Server {Key} will launch in a visible window. Server log file: {ServerLog}",
+                instance.Key,
+                robustLogFile);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Server {Key} process logs: stdout={StdoutLog}, stderr={StderrLog}, serverLog={ServerLog}",
+                instance.Key,
+                Path.Combine(logDirectory, "server.out.log"),
+                Path.Combine(logDirectory, "server.err.log"),
+                robustLogFile);
+        }
+
         var startInfo = new ProcessStartInfo();
         startInfo.FileName = data.Program;
         startInfo.WorkingDirectory = data.WorkingDirectory;
-        startInfo.UseShellExecute = false;
+        startInfo.UseShellExecute = _options.Value.LaunchInNewWindow;
+        startInfo.CreateNoWindow = false;
+        startInfo.RedirectStandardOutput = !_options.Value.LaunchInNewWindow;
+        startInfo.RedirectStandardError = !_options.Value.LaunchInNewWindow;
 
         foreach (var argument in data.Arguments)
         {
@@ -55,23 +80,54 @@ public sealed class ProcessManagerBasic : IProcessManager
             startInfo.ArgumentList.Add(argument);
         }
 
-        foreach (var (var, value) in data.EnvironmentVariables)
+        if (!startInfo.UseShellExecute)
         {
-            _logger.LogTrace("Env: {EnvVar} = {EnvValue}", var, value);
-            startInfo.EnvironmentVariables[var] = value;
+            foreach (var (var, value) in data.EnvironmentVariables)
+            {
+                _logger.LogTrace("Env: {EnvVar} = {EnvValue}", var, value);
+                startInfo.EnvironmentVariables[var] = value;
+            }
+
+            startInfo.EnvironmentVariables["ROBUST_LOG_FILE"] = robustLogFile;
         }
 
         _logger.LogDebug("Launching...");
+
+        StreamWriter? stdoutLog = null;
+        StreamWriter? stderrLog = null;
+
         Process? process;
         try
         {
-            process = Process.Start(startInfo);
+            if (_options.Value.LaunchInNewWindow)
+            {
+                process = StartServerInNewWindow(startInfo, data, robustLogFile);
+            }
+            else
+            {
+                stdoutLog = OpenProcessLog(logDirectory, "server.out.log");
+                stderrLog = OpenProcessLog(logDirectory, "server.err.log");
+                var stdoutWriter = stdoutLog;
+                var stderrWriter = stderrLog;
+
+                process = Process.Start(startInfo);
+
+                if (process == null)
+                    throw new Exception("No process was started??");
+
+                process.OutputDataReceived += (_, e) => WriteProcessOutput(stdoutWriter, e.Data);
+                process.ErrorDataReceived += (_, e) => WriteProcessOutput(stderrWriter, e.Data);
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+            }
 
             if (process == null)
                 throw new Exception("No process was started??");
         }
         catch (Exception e)
         {
+            stdoutLog?.Dispose();
+            stderrLog?.Dispose();
             _logger.LogError(e, "Process launch failed!");
             throw;
         }
@@ -84,7 +140,71 @@ public sealed class ProcessManagerBasic : IProcessManager
             PersistPid(instance, process);
         }
 
-        return Task.FromResult<IProcessHandle>(new Handle(process));
+        return Task.FromResult<IProcessHandle>(new Handle(process, stdoutLog, stderrLog));
+    }
+
+    private static Process? StartServerInNewWindow(
+        ProcessStartInfo startInfo,
+        ProcessStartData data,
+        string robustLogFile)
+    {
+        lock (EnvironmentLock)
+        {
+            var previousValues = new (string Name, string? Value)[data.EnvironmentVariables.Count + 1];
+            var i = 0;
+            try
+            {
+                foreach (var (name, value) in data.EnvironmentVariables)
+                {
+                    previousValues[i++] = (name, Environment.GetEnvironmentVariable(name));
+                    Environment.SetEnvironmentVariable(name, value);
+                }
+
+                previousValues[i++] = ("ROBUST_LOG_FILE", Environment.GetEnvironmentVariable("ROBUST_LOG_FILE"));
+                Environment.SetEnvironmentVariable("ROBUST_LOG_FILE", robustLogFile);
+
+                return Process.Start(startInfo);
+            }
+            finally
+            {
+                for (var j = 0; j < i; j++)
+                    Environment.SetEnvironmentVariable(previousValues[j].Name, previousValues[j].Value);
+            }
+        }
+    }
+
+    private static string EnsureLogDirectory(IServerInstance instance)
+    {
+        var logDirectory = Path.Combine(instance.InstanceDir, "logs");
+        Directory.CreateDirectory(logDirectory);
+        return logDirectory;
+    }
+
+    private static StreamWriter OpenProcessLog(string logDirectory, string fileName)
+    {
+        return new StreamWriter(
+            new FileStream(Path.Combine(logDirectory, fileName), FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+        {
+            AutoFlush = true
+        };
+    }
+
+    private static void WriteProcessOutput(TextWriter writer, string? message)
+    {
+        if (message == null)
+            return;
+
+        lock (writer)
+        {
+            try
+            {
+                writer.WriteLine(message);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Process output events can arrive while the handle is being cleaned up.
+            }
+        }
     }
 
     private void PersistPid(IServerInstance instance, Process process)
@@ -167,11 +287,15 @@ public sealed class ProcessManagerBasic : IProcessManager
     private sealed class Handle : IProcessHandle
     {
         private readonly Process _process;
+        private readonly TextWriter? _stdoutLog;
+        private readonly TextWriter? _stderrLog;
         public bool IsRecovered;
 
-        public Handle(Process process)
+        public Handle(Process process, TextWriter? stdoutLog = null, TextWriter? stderrLog = null)
         {
             _process = process;
+            _stdoutLog = stdoutLog;
+            _stderrLog = stderrLog;
         }
 
         public void DumpProcess(string file, DumpType type)
@@ -183,6 +307,8 @@ public sealed class ProcessManagerBasic : IProcessManager
         public async Task WaitForExitAsync(CancellationToken cancel = default)
         {
             await _process.WaitForExitAsync(cancel);
+            _process.WaitForExit();
+            await DisposeLogsAsync();
         }
 
         public Task<ProcessExitStatus?> GetExitStatusAsync()
@@ -206,6 +332,19 @@ public sealed class ProcessManagerBasic : IProcessManager
             _process.Kill(entireProcessTree: true);
 
             return Task.CompletedTask;
+        }
+
+        private async Task DisposeLogsAsync()
+        {
+            if (_stdoutLog is IAsyncDisposable asyncStdout)
+                await asyncStdout.DisposeAsync();
+            else
+                _stdoutLog?.Dispose();
+
+            if (_stderrLog is IAsyncDisposable asyncStderr)
+                await asyncStderr.DisposeAsync();
+            else
+                _stderrLog?.Dispose();
         }
     }
 }

--- a/SS14.Watchdog/Components/ProcessManagement/ProcessOptions.cs
+++ b/SS14.Watchdog/Components/ProcessManagement/ProcessOptions.cs
@@ -16,6 +16,12 @@ public class ProcessOptions
     public bool PersistServers { get; set; } = false;
 
     /// <summary>
+    /// Whether to launch game server processes in their own visible shell window.
+    /// This is intended for local development and starter hosting, not unattended deployments.
+    /// </summary>
+    public bool LaunchInNewWindow { get; set; } = false;
+
+    /// <summary>
     /// Controls how the watchdog manages game server processes.
     /// </summary>
     public ProcessMode Mode { get; set; } = ProcessMode.Basic;

--- a/SS14.Watchdog/Components/ServerManagement/ServerInstance.Actor.cs
+++ b/SS14.Watchdog/Components/ServerManagement/ServerInstance.Actor.cs
@@ -48,31 +48,37 @@ public sealed partial class ServerInstance
     {
         _baseServerAddress = baseServerAddress;
 
-        _logger.LogDebug("Starting server {Key}", Key);
-
-        await TryLoadPersistedProcess(cancel);
-        await _commandQueue.Writer.WriteAsync(new CommandStart(), cancel);
-
-        try
+        using (_logger.BeginScope(new Dictionary<string, object>
+               {
+                   ["Instance"] = Key
+               }))
         {
-            await CommandLoop(cancel);
+            _logger.LogDebug("Starting server {Key}", Key);
 
-            // Currently no way for this to be reachable, as shutdown is always caused by cancellation.
-        }
-        catch (OperationCanceledException)
-        {
-            // Nada, expected shutdown sequence.
-        }
-        catch (Exception e)
-        {
-            // Oh fuck.
-            _logger.LogCritical(e, "Exception occurred in server instance loop!");
-        }
-        finally
-        {
-            // Whether clean or unclear, run shutdown logic to the best of our abilities.
+            await TryLoadPersistedProcess(cancel);
+            await _commandQueue.Writer.WriteAsync(new CommandStart(), cancel);
 
-            await ShutdownAsync();
+            try
+            {
+                await CommandLoop(cancel);
+
+                // Currently no way for this to be reachable, as shutdown is always caused by cancellation.
+            }
+            catch (OperationCanceledException)
+            {
+                // Nada, expected shutdown sequence.
+            }
+            catch (Exception e)
+            {
+                // Oh fuck.
+                _logger.LogCritical(e, "Exception occurred in server instance loop!");
+            }
+            finally
+            {
+                // Whether clean or unclear, run shutdown logic to the best of our abilities.
+
+                await ShutdownAsync();
+            }
         }
     }
 
@@ -307,9 +313,11 @@ public sealed partial class ServerInstance
         {
             _updateOnRestart = false;
 
-            await StartRunUpdate(cancel);
+            if (!await StartRunUpdate(cancel))
+                return;
         }
 
+        await EnsureFirstRunFiles(cancel);
         GenerateNewToken();
 
         {
@@ -328,6 +336,9 @@ public sealed partial class ServerInstance
 
         _logger.LogTrace("Getting launch info...");
 
+        var configFile = Path.Combine(InstanceDir, "config.toml");
+        var dataDir = Path.Combine(InstanceDir, "data");
+
         var args = new List<string>
         {
             // Watchdog comms config.
@@ -336,8 +347,8 @@ public sealed partial class ServerInstance
             // watchdog.token provided through ENV vars, as this does not show up in process listings
             // like `ps -aux` or `htop`.
 
-            "--config-file", Path.Combine(InstanceDir, "config.toml"),
-            "--data-dir", Path.Combine(InstanceDir, "data"),
+            "--config-file", configFile,
+            "--data-dir", dataDir,
         };
 
         // Prepare the user provided arguments
@@ -373,7 +384,11 @@ public sealed partial class ServerInstance
             args,
             env);
 
-        _logger.LogTrace("Launching...");
+        _logger.LogInformation(
+            "Launching server {Key}",
+            Key);
+
+        _logger.LogDebug("Launching...");
         try
         {
             _runningServer = await _processManager.StartServer(this, startData, cancel);
@@ -386,6 +401,27 @@ public sealed partial class ServerInstance
 
         MonitorServer(_startNumber, cancel);
         StartTimeoutTimer();
+    }
+
+    private async Task EnsureFirstRunFiles(CancellationToken cancel)
+    {
+        Directory.CreateDirectory(Path.Combine(InstanceDir, "data"));
+        Directory.CreateDirectory(Path.Combine(InstanceDir, "binaries"));
+        Directory.CreateDirectory(Path.Combine(InstanceDir, "logs"));
+        Directory.CreateDirectory(Path.Combine(InstanceDir, "dumps"));
+
+        var configFile = Path.Combine(InstanceDir, "config.toml");
+        if (!File.Exists(configFile))
+        {
+            if (_updateProvider != null &&
+                await _updateProvider.TryWriteFirstRunConfigAsync(configFile, cancel))
+            {
+                return;
+            }
+
+            _logger.LogInformation("No config.toml found for {Key}, creating empty {ConfigFile}", Key, configFile);
+            await File.WriteAllTextAsync(configFile, "", cancel);
+        }
     }
 
     private string GetProgramPath()
@@ -421,10 +457,10 @@ public sealed partial class ServerInstance
         }
     }
 
-    private async Task StartRunUpdate(CancellationToken cancel)
+    private async Task<bool> StartRunUpdate(CancellationToken cancel)
     {
         if (_updateProvider == null)
-            return;
+            return true;
 
         bool hasUpdate;
         try
@@ -436,11 +472,11 @@ public sealed partial class ServerInstance
         catch (Exception e)
         {
             _logger.LogError(e, "Error while checking for update!");
-            return;
+            return true;
         }
 
         if (!hasUpdate)
-            return;
+            return true;
 
         _logger.LogTrace("Starting update...");
         string? newRevision;
@@ -454,7 +490,7 @@ public sealed partial class ServerInstance
         catch (Exception e)
         {
             _logger.LogError(e, "Uncaught error while updating server");
-            return;
+            return false;
         }
 
         if (newRevision != null)
@@ -466,11 +502,11 @@ public sealed partial class ServerInstance
             _loadFailCount = 0;
             _currentRevision = newRevision;
             SaveData();
+            return true;
         }
-        else
-        {
-            _logger.LogError("Failed to update!");
-        }
+
+        _logger.LogError("Failed to update; not starting server because required binaries may be missing or stale.");
+        return false;
     }
 
     /// <summary>

--- a/SS14.Watchdog/Components/ServerManagement/ServerManager.cs
+++ b/SS14.Watchdog/Components/ServerManagement/ServerManager.cs
@@ -99,6 +99,8 @@ namespace SS14.Watchdog.Components.ServerManagement
             _serverCfg.OnChange(CfgChanged);
 
             var options = _serverCfg.CurrentValue;
+            ValidateConfiguration(options);
+
             var instanceRoot = Path.Combine(Environment.CurrentDirectory, options.InstanceRoot);
 
             if (!Directory.Exists(instanceRoot))
@@ -143,6 +145,105 @@ namespace SS14.Watchdog.Components.ServerManagement
 
             // This calls ExecuteAsync
             await base.StartAsync(cancellationToken);
+        }
+
+        private void ValidateConfiguration(ServersConfiguration options)
+        {
+            _logger.LogInformation(
+                "Validating watchdog server configuration for {InstanceCount} instance(s)",
+                options.Instances.Count);
+
+            var errors = new List<string>();
+            var ports = new Dictionary<ushort, string>();
+
+            if (options.Instances.Count == 0)
+            {
+                _logger.LogWarning("No server instances are configured.");
+            }
+
+            foreach (var (key, instance) in options.Instances)
+            {
+                LogInstanceConfiguration(key, instance);
+                ValidateApiPort(key, instance, ports, errors);
+                WarnIfApiTokenMissing(key, instance);
+                ValidateBaseUrl(key, instance, errors);
+            }
+
+            if (errors.Count == 0)
+            {
+                _logger.LogInformation("Watchdog server configuration validation passed.");
+                return;
+            }
+
+            foreach (var error in errors)
+            {
+                _logger.LogError("Configuration error: {Error}", error);
+            }
+
+            throw new InvalidOperationException("Invalid watchdog server configuration: " + string.Join(" ", errors));
+        }
+
+        private void LogInstanceConfiguration(string key, InstanceConfiguration instance)
+        {
+            _logger.LogInformation(
+                "Configured instance {Key}: name={Name}, apiPort={ApiPort}, updateType={UpdateType}",
+                key,
+                instance.Name ?? "<unnamed>",
+                instance.ApiPort,
+                instance.UpdateType ?? "<none>");
+        }
+
+        private static void ValidateApiPort(
+            string key,
+            InstanceConfiguration instance,
+            Dictionary<ushort, string> ports,
+            List<string> errors)
+        {
+            if (instance.ApiPort == 0)
+            {
+                errors.Add($"Instance '{key}' must set Servers:Instances:{key}:ApiPort.");
+                return;
+            }
+
+            if (!ports.TryAdd(instance.ApiPort, key))
+            {
+                errors.Add(
+                    $"Instances '{ports[instance.ApiPort]}' and '{key}' both use ApiPort {instance.ApiPort}.");
+            }
+        }
+
+        private void WarnIfApiTokenMissing(string key, InstanceConfiguration instance)
+        {
+            if (!string.IsNullOrWhiteSpace(instance.ApiToken) ||
+                !string.IsNullOrWhiteSpace(instance.ApiTokenFile))
+            {
+                return;
+            }
+
+            _logger.LogWarning(
+                "Instance {Key} has no ApiToken or ApiTokenFile configured; watchdog admin API calls for this instance will not be usable.",
+                key);
+        }
+
+        private void ValidateBaseUrl(string key, InstanceConfiguration instance, List<string> errors)
+        {
+            if (!UpdateProviderNeedsBaseUrl(key, instance))
+                return;
+
+            if (string.IsNullOrWhiteSpace(_configuration["BaseUrl"]))
+            {
+                errors.Add(
+                    $"Instance '{key}' uses {instance.UpdateType} updates and requires a root BaseUrl in configuration.");
+            }
+        }
+
+        private bool UpdateProviderNeedsBaseUrl(string key, InstanceConfiguration instance)
+        {
+            if (instance.UpdateType == "Local")
+                return true;
+
+            var hybridAcz = _configuration.GetValue<bool?>($"Servers:Instances:{key}:Updates:HybridACZ") ?? true;
+            return instance.UpdateType == "Git" && !hybridAcz;
         }
 
         private void CfgChanged(ServersConfiguration obj)

--- a/SS14.Watchdog/Components/Updates/UpdateProvider.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProvider.cs
@@ -43,6 +43,11 @@ namespace SS14.Watchdog.Components.Updates
             return Enumerable.Empty<KeyValuePair<string, string>>();
         }
 
+        public virtual Task<bool> TryWriteFirstRunConfigAsync(string configFile, CancellationToken cancel = default)
+        {
+            return Task.FromResult(false);
+        }
+
         [Pure]
         protected static string GetHostSS14RID()
         {

--- a/SS14.Watchdog/Components/Updates/UpdateProviderDummy.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderDummy.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace SS14.Watchdog.Components.Updates
 {
     /// <summary>
-    /// Test provider that always reports an update and advances the recorded revision without copying files.
+    ///     Always reports that an update is available.
     /// </summary>
     public sealed class UpdateProviderDummy : UpdateProvider
     {

--- a/SS14.Watchdog/Components/Updates/UpdateProviderDummy.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderDummy.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace SS14.Watchdog.Components.Updates
 {
     /// <summary>
-    ///     Pretends an update is always available.
+    /// Test provider that always reports an update and advances the recorded revision without copying files.
     /// </summary>
     public sealed class UpdateProviderDummy : UpdateProvider
     {

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -17,12 +17,8 @@ using SS14.Watchdog.Configuration.Updates;
 namespace SS14.Watchdog.Components.Updates
 {
     /// <summary>
-    /// Builds and packages the server from a Git repository on the watchdog host, then applies the produced
-    /// server zip as the instance's server binaries. Use this for local development or hosts that intentionally
-    /// build from source on the deployment machine. It requires Git, .NET, and optionally Python depending on
-    /// the repository packaging layout.
+    ///     Builds updates from a Git repository.
     /// </summary>
-    /// <seealso cref="UpdateProviderGitConfiguration"/>
     public class UpdateProviderGit : UpdateProvider
     {
         private readonly ServerInstance _serverInstance;

--- a/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderGit.cs
@@ -16,6 +16,13 @@ using SS14.Watchdog.Configuration.Updates;
 
 namespace SS14.Watchdog.Components.Updates
 {
+    /// <summary>
+    /// Builds and packages the server from a Git repository on the watchdog host, then applies the produced
+    /// server zip as the instance's server binaries. Use this for local development or hosts that intentionally
+    /// build from source on the deployment machine. It requires Git, .NET, and optionally Python depending on
+    /// the repository packaging layout.
+    /// </summary>
+    /// <seealso cref="UpdateProviderGitConfiguration"/>
     public class UpdateProviderGit : UpdateProvider
     {
         private readonly ServerInstance _serverInstance;
@@ -38,12 +45,19 @@ namespace SS14.Watchdog.Components.Updates
             _configuration = config;
         }
 
-        private async Task<int> CommandHelper(string cd, string command, string[] args, CancellationToken cancel = default)
+        private async Task<CommandResult> CommandHelper(string cd, string command, string[] args, CancellationToken cancel = default)
         {
             var si = new ProcessStartInfo {
-                FileName = command, CreateNoWindow = true, UseShellExecute = true,
-                WorkingDirectory = cd
+                FileName = command,
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
             };
+
+            if (!string.IsNullOrWhiteSpace(cd))
+                si.WorkingDirectory = cd;
+
             // MSDN lied to me! https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.argumentlist?view=net-6.0
             foreach (var s in args)
                 si.ArgumentList.Add(s);
@@ -52,10 +66,31 @@ namespace SS14.Watchdog.Components.Updates
                 StartInfo = si
             };
             proc.Start();
-            await proc.WaitForExitAsync(cancel);
-            if (cancel.IsCancellationRequested)
-                return 127;
-            return proc.ExitCode;
+
+            var stdoutTask = proc.StandardOutput.ReadToEndAsync(cancel);
+            var stderrTask = proc.StandardError.ReadToEndAsync(cancel);
+
+            try
+            {
+                await proc.WaitForExitAsync(cancel);
+                return new CommandResult(
+                    proc.ExitCode,
+                    await stdoutTask,
+                    await stderrTask);
+            }
+            catch (OperationCanceledException)
+            {
+                try
+                {
+                    proc.Kill(entireProcessTree: true);
+                }
+                catch (InvalidOperationException)
+                {
+                    // Process already exited.
+                }
+
+                throw;
+            }
         }
 
         private async Task CommandHelperChecked(string reason, string cd, string command, string[] args, CancellationToken cancel = default)
@@ -63,7 +98,18 @@ namespace SS14.Watchdog.Components.Updates
             int exitCode;
             try
             {
-                exitCode = await CommandHelper(cd, command, args, cancel);
+                var result = await CommandHelper(cd, command, args, cancel);
+                exitCode = result.ExitCode;
+                if (exitCode != 0)
+                {
+                    _logger.LogWarning(
+                        "Command failed while running {Command} {Arguments}. Exit code: {ExitCode}. Stdout: {Stdout}. Stderr: {Stderr}",
+                        command,
+                        string.Join(" ", args),
+                        result.ExitCode,
+                        result.Stdout,
+                        result.Stderr);
+                }
             }
             catch (Exception ex)
             {
@@ -80,7 +126,9 @@ namespace SS14.Watchdog.Components.Updates
             try
             {
                 var si = new ProcessStartInfo {
-                    FileName = command, CreateNoWindow = true,
+                    FileName = command,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
                     WorkingDirectory = cd,
                     RedirectStandardOutput = true
                 };
@@ -111,7 +159,7 @@ namespace SS14.Watchdog.Components.Updates
         {
             try
             {
-                return await CommandHelper(_repoPath, "git", new[] {"status"}) == 0;
+                return (await CommandHelper(_repoPath, "git", new[] {"status"})).ExitCode == 0;
             }
             catch (Exception)
             {
@@ -121,7 +169,12 @@ namespace SS14.Watchdog.Components.Updates
 
         private async Task<bool> GitFetchOrigin(CancellationToken cancel = default)
         {
-            return await CommandHelper(_repoPath, "git", new[] {"fetch", _baseUrl, _branch}, cancel) == 0;
+            _logger.LogInformation("Fetching git updates for {Key} from {Repository} branch {Branch}.",
+                _serverInstance.Key,
+                _baseUrl,
+                _branch);
+
+            return (await CommandHelper(_repoPath, "git", new[] {"fetch", _baseUrl, _branch}, cancel)).ExitCode == 0;
         }
 
         private async Task GitSwitchBranch(CancellationToken cancel = default)
@@ -132,36 +185,80 @@ namespace SS14.Watchdog.Components.Updates
 
         private async Task GitCheckedSubmoduleUpdate(CancellationToken cancel = default)
         {
+            _logger.LogInformation("Updating git submodules for {Key}.", _serverInstance.Key);
+
             await CommandHelperChecked("Failed submodule update!", _repoPath, "git", new[] {"submodule", "update", "--init", "--depth=1", "--recursive"}, cancel);
         }
 
         private async Task GitResetToFetchHead(CancellationToken cancel = default)
         {
+            _logger.LogInformation("Resetting git repository for {Key} to fetched HEAD.", _serverInstance.Key);
+
             await CommandHelperChecked("Failed reset to fetch-head", _repoPath, "git", new[] {"reset", "--hard", "FETCH_HEAD"}, cancel);
         }
 
         private async Task TryClone(CancellationToken cancel = default)
         {
-            _logger.LogTrace("Cloning git repository...");
+            _logger.LogInformation(
+                "Cloning git repository for {Key} from {Repository} branch {Branch} into {Path}.",
+                _serverInstance.Key,
+                _baseUrl,
+                _branch,
+                _repoPath);
 
-            if(Directory.Exists(_repoPath))
-                Directory.Delete(_repoPath, true);
+            if (Directory.Exists(_repoPath))
+                await DeleteDirectoryWithRetry(_repoPath, cancel);
 
             try
             {
                 // NOTE: These are expected to prepare everything including submodules,
                 // because this is used for orbital nuking in the event of an update issue.
                 // The --depth=1 is a performance cheat. Works though.
-                await CommandHelperChecked("Failed initial clone!", "", "git", new[] {"clone", "--depth=1", _baseUrl, _repoPath}, cancel);
+                await CommandHelperChecked("Failed initial clone!", "", "git", new[] {"clone", "--depth=1", "--branch", _branch, _baseUrl, _repoPath}, cancel);
                 await GitFetchOrigin(cancel);
                 await GitResetToFetchHead(cancel);
                 await GitCheckedSubmoduleUpdate(cancel);
+
+                _logger.LogInformation("Finished cloning git repository for {Key}.", _serverInstance.Key);
             }
             catch (Exception)
             {
-                if(Directory.Exists(_repoPath))
-                    Directory.Delete(_repoPath, true);
+                if (Directory.Exists(_repoPath))
+                    await DeleteDirectoryWithRetry(_repoPath, cancel);
                 throw;
+            }
+        }
+
+        private async Task DeleteDirectoryWithRetry(string path, CancellationToken cancel)
+        {
+            const int attempts = 5;
+
+            for (var i = 1; i <= attempts; i++)
+            {
+                try
+                {
+                    Directory.Delete(path, true);
+                    return;
+                }
+                catch (Exception e) when (i < attempts && e is IOException or UnauthorizedAccessException)
+                {
+                    _logger.LogWarning(
+                        e,
+                        "Failed to delete git source directory {Path} on attempt {Attempt}/{Attempts}; retrying.",
+                        path,
+                        i,
+                        attempts);
+
+                    await Task.Delay(TimeSpan.FromMilliseconds(500 * i), cancel);
+                }
+                catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+                {
+                    _logger.LogError(
+                        e,
+                        "Failed to delete git source directory {Path}. A previous git process may still have files open.",
+                        path);
+                    throw;
+                }
             }
         }
 
@@ -175,6 +272,39 @@ namespace SS14.Watchdog.Components.Updates
             {
                 return null;
             }
+        }
+
+        public override async Task<bool> TryWriteFirstRunConfigAsync(string configFile, CancellationToken cancel = default)
+        {
+            var sourceConfig = GetFirstRunConfigTemplatePath();
+            if (sourceConfig == null)
+            {
+                _logger.LogInformation(
+                    "No git repository server_config.toml template found for {Key}; creating an empty config.toml instead.",
+                    _serverInstance.Key);
+                return false;
+            }
+
+            _logger.LogInformation(
+                "Creating first-run config for {Key} from git repository template {SourceConfig}.",
+                _serverInstance.Key,
+                sourceConfig);
+
+            await using var source = File.OpenRead(sourceConfig);
+            await using var destination = File.Create(configFile);
+            await source.CopyToAsync(destination, cancel);
+            return true;
+        }
+
+        private string? GetFirstRunConfigTemplatePath()
+        {
+            var candidates = new[]
+            {
+                Path.Combine(_repoPath, "Content.Server", "server_config.toml"),
+                Path.Combine(_repoPath, "bin", "Content.Server", "server_config.toml")
+            };
+
+            return candidates.FirstOrDefault(File.Exists);
         }
 
         // Updater and checker
@@ -199,7 +329,12 @@ namespace SS14.Watchdog.Components.Updates
                 update = true;
             }
 
-            _logger.LogInformation($"Update check: {head ?? "No head"}, {fetchHead ?? "No fetch-head"} - updating: {update}");
+            _logger.LogInformation(
+                "Git update check for {Key}: head={Head}, fetchHead={FetchHead}, updating={Update}",
+                _serverInstance.Key,
+                head ?? "No head",
+                fetchHead ?? "No fetch-head",
+                update);
             return update;
         }
 
@@ -224,16 +359,20 @@ namespace SS14.Watchdog.Components.Updates
                 {
                     try
                     {
-                        // Don't allow these to be cancelled as they could probably corrupt the repository.
                         if (!(await GitFetchOrigin(cancel)))
                             throw new Exception("Could not fetch origin");
+                        var fetchedHead = await GitHead("FETCH_HEAD");
+                        _logger.LogInformation(
+                            "Fetched git branch {Branch} for {Key} at {FetchedHead}.",
+                            _branch,
+                            _serverInstance.Key,
+                            fetchedHead ?? "No fetch-head");
                         await GitResetToFetchHead(cancel);
                         await GitCheckedSubmoduleUpdate(cancel);
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogWarning($"Failed git submodule update: {ex}");
-                        _logger.LogWarning($"Nuking the repository from orbit to recover!");
+                        _logger.LogWarning(ex, "Failed to update git repository, recloning to recover.");
                         await TryClone(cancel);
                     }
                 }
@@ -242,7 +381,9 @@ namespace SS14.Watchdog.Components.Updates
                 if (actualConfirmedHead == null)
                     throw new Exception("Head disappeared!");
 
-                _logger.LogDebug($"Went from {currentVersion} to {actualConfirmedHead}");
+                _logger.LogDebug("Git update moved from {CurrentVersion} to {NewVersion}",
+                    currentVersion,
+                    actualConfirmedHead);
 
                 // Now we build and package it.
 
@@ -376,6 +517,8 @@ namespace SS14.Watchdog.Components.Updates
                 return null;
             }
         }
+
+        private sealed record CommandResult(int ExitCode, string Stdout, string Stderr);
 
         private class Build
         {

--- a/SS14.Watchdog/Components/Updates/UpdateProviderJenkins.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderJenkins.cs
@@ -12,11 +12,8 @@ using SS14.Watchdog.Utility;
 namespace SS14.Watchdog.Components.Updates
 {
     /// <summary>
-    /// Fetches the last successful Jenkins build for a configured job, downloads the current platform's
-    /// server zip from that build's release artifacts, and applies it as the instance's server binaries.
-    /// Use this for legacy Jenkins-based publishing pipelines.
+    ///     Downloads updates from a Jenkins job.
     /// </summary>
-    /// <seealso cref="UpdateProviderJenkinsConfiguration"/>
     public sealed class UpdateProviderJenkins : UpdateProvider
     {
         private readonly HttpClient _httpClient = new HttpClient();

--- a/SS14.Watchdog/Components/Updates/UpdateProviderJenkins.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderJenkins.cs
@@ -12,8 +12,11 @@ using SS14.Watchdog.Utility;
 namespace SS14.Watchdog.Components.Updates
 {
     /// <summary>
-    ///     Update providers that pulls the latest build of a Jenkins job as updates.
+    /// Fetches the last successful Jenkins build for a configured job, downloads the current platform's
+    /// server zip from that build's release artifacts, and applies it as the instance's server binaries.
+    /// Use this for legacy Jenkins-based publishing pipelines.
     /// </summary>
+    /// <seealso cref="UpdateProviderJenkinsConfiguration"/>
     public sealed class UpdateProviderJenkins : UpdateProvider
     {
         private readonly HttpClient _httpClient = new HttpClient();

--- a/SS14.Watchdog/Components/Updates/UpdateProviderLocal.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderLocal.cs
@@ -13,11 +13,8 @@ using SS14.Watchdog.Configuration.Updates;
 namespace SS14.Watchdog.Components.Updates
 {
     /// <summary>
-    /// Treats files already placed in the instance directory as the deployed build and only updates the
-    /// recorded revision. This provider does not copy server files; external tooling or an operator is
-    /// responsible for putting server and optional client artifacts in the expected instance directories.
+    ///     Tracks updates for files managed outside watchdog.
     /// </summary>
-    /// <seealso cref="UpdateProviderLocalConfiguration"/>
     public sealed class UpdateProviderLocal : UpdateProvider
     {
         private readonly IServerInstance _serverInstance;

--- a/SS14.Watchdog/Components/Updates/UpdateProviderLocal.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderLocal.cs
@@ -13,8 +13,11 @@ using SS14.Watchdog.Configuration.Updates;
 namespace SS14.Watchdog.Components.Updates
 {
     /// <summary>
-    ///     Update provider that allows doing manual updates on local files as updating method.
+    /// Treats files already placed in the instance directory as the deployed build and only updates the
+    /// recorded revision. This provider does not copy server files; external tooling or an operator is
+    /// responsible for putting server and optional client artifacts in the expected instance directories.
     /// </summary>
+    /// <seealso cref="UpdateProviderLocalConfiguration"/>
     public sealed class UpdateProviderLocal : UpdateProvider
     {
         private readonly IServerInstance _serverInstance;

--- a/SS14.Watchdog/Components/Updates/UpdateProviderManifest.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderManifest.cs
@@ -18,12 +18,8 @@ using SS14.Watchdog.Utility;
 namespace SS14.Watchdog.Components.Updates
 {
     /// <summary>
-    /// Fetches a build manifest, selects the newest listed build, downloads the compatible server zip for
-    /// the current runtime identifier, verifies its SHA-256 hash, and applies it as the instance's server
-    /// binaries. Use this when a publishing pipeline produces an SS14-style manifest with platform-specific
-    /// server artifacts.
+    ///     Downloads updates from a build manifest. See Content.Packaging
     /// </summary>
-    /// <seealso cref="UpdateProviderManifestConfiguration"/>
     public sealed class UpdateProviderManifest : UpdateProvider
     {
         private const int DownloadTimeoutSeconds = 120;

--- a/SS14.Watchdog/Components/Updates/UpdateProviderManifest.cs
+++ b/SS14.Watchdog/Components/Updates/UpdateProviderManifest.cs
@@ -17,6 +17,13 @@ using SS14.Watchdog.Utility;
 
 namespace SS14.Watchdog.Components.Updates
 {
+    /// <summary>
+    /// Fetches a build manifest, selects the newest listed build, downloads the compatible server zip for
+    /// the current runtime identifier, verifies its SHA-256 hash, and applies it as the instance's server
+    /// binaries. Use this when a publishing pipeline produces an SS14-style manifest with platform-specific
+    /// server artifacts.
+    /// </summary>
+    /// <seealso cref="UpdateProviderManifestConfiguration"/>
     public sealed class UpdateProviderManifest : UpdateProvider
     {
         private const int DownloadTimeoutSeconds = 120;

--- a/SS14.Watchdog/Configuration/Updates/UpdateProviderGitConfiguration.cs
+++ b/SS14.Watchdog/Configuration/Updates/UpdateProviderGitConfiguration.cs
@@ -1,12 +1,24 @@
 namespace SS14.Watchdog.Configuration.Updates
 {
+    /// <summary>
+    /// Configuration for <see cref="SS14.Watchdog.Components.Updates.UpdateProviderGit"/>.
+    /// </summary>
     public class UpdateProviderGitConfiguration
     {
-        /// <summary> Git repository URL. Not to be confused with the other BaseUrl. </summary>
+        /// <summary>
+        /// Git repository URL. This is the source repository URL, not the watchdog root BaseUrl.
+        /// </summary>
         public string BaseUrl { get; set; } = null!;
-        /// <summary> Git repository branch. </summary>
+
+        /// <summary>
+        /// Git branch to fetch, reset to, and package.
+        /// </summary>
         public string Branch { get; set; } = "master";
-        /// <summary> Hybrid ACZ hosts the client zip on the status host for easier port forwarding (no need to forward the watchdog port). </summary>
+
+        /// <summary>
+        /// Whether to build a hybrid ACZ server package. When enabled, the client zip is hosted by the status host,
+        /// so operators do not need to expose watchdog's binaries endpoint.
+        /// </summary>
         public bool HybridACZ { get; set; } = true;
     }
 }

--- a/SS14.Watchdog/Configuration/Updates/UpdateProviderJenkinsConfiguration.cs
+++ b/SS14.Watchdog/Configuration/Updates/UpdateProviderJenkinsConfiguration.cs
@@ -1,8 +1,18 @@
 namespace SS14.Watchdog.Configuration.Updates
 {
+    /// <summary>
+    /// Configuration for <see cref="SS14.Watchdog.Components.Updates.UpdateProviderJenkins"/>.
+    /// </summary>
     public sealed class UpdateProviderJenkinsConfiguration
     {
+        /// <summary>
+        /// Base URL of the Jenkins instance, without a trailing job path.
+        /// </summary>
         public string BaseUrl { get; set; } = null!;
+
+        /// <summary>
+        /// Jenkins job name to query for the last successful build.
+        /// </summary>
         public string JobName { get; set; } = null!;
     }
 }

--- a/SS14.Watchdog/Configuration/Updates/UpdateProviderLocalConfiguration.cs
+++ b/SS14.Watchdog/Configuration/Updates/UpdateProviderLocalConfiguration.cs
@@ -1,7 +1,14 @@
 namespace SS14.Watchdog.Configuration.Updates
 {
+    /// <summary>
+    /// Configuration for <see cref="SS14.Watchdog.Components.Updates.UpdateProviderLocal"/>.
+    /// </summary>
     public sealed class UpdateProviderLocalConfiguration
     {
+        /// <summary>
+        /// Version string that watchdog records as the active revision when local files should be considered updated.
+        /// Change this value after replacing files externally to make watchdog restart into the new revision.
+        /// </summary>
         public string CurrentVersion { get; set; } = null!;
     }
 }

--- a/SS14.Watchdog/Configuration/Updates/UpdateProviderManifestConfiguration.cs
+++ b/SS14.Watchdog/Configuration/Updates/UpdateProviderManifestConfiguration.cs
@@ -1,14 +1,34 @@
 ﻿namespace SS14.Watchdog.Configuration.Updates
 {
+    /// <summary>
+    /// Configuration for <see cref="SS14.Watchdog.Components.Updates.UpdateProviderManifest"/>.
+    /// </summary>
     public class UpdateProviderManifestConfiguration
     {
+        /// <summary>
+        /// URL of the SS14 build manifest JSON to fetch.
+        /// </summary>
         public string ManifestUrl { get; set; } = null!;
+
+        /// <summary>
+        /// Optional basic authentication credentials for fetching the manifest and referenced artifacts.
+        /// </summary>
         public ManifestAuthenticationConfiguration? Authentication { get; set; }
     }
 
+    /// <summary>
+    /// Basic authentication credentials for manifest update downloads.
+    /// </summary>
     public sealed class ManifestAuthenticationConfiguration
     {
+        /// <summary>
+        /// Basic authentication username.
+        /// </summary>
         public string? Username { get; set; }
+
+        /// <summary>
+        /// Basic authentication password.
+        /// </summary>
         public string? Password { get; set; }
     }
 }

--- a/SS14.Watchdog/Program.cs
+++ b/SS14.Watchdog/Program.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Serilog;
+using Serilog.Events;
 using Serilog.Sinks.Loki;
 using Serilog.Sinks.Loki.Labels;
 
@@ -28,10 +30,32 @@ namespace SS14.Watchdog
                 .UseSerilog((ctx, cfg) =>
                 {
                     cfg.ReadFrom.Configuration(ctx.Configuration);
+                    cfg.Enrich.FromLogContext();
 
                     SetupLoki(cfg, ctx.Configuration);
+                    SetupInstanceFileLogging(cfg);
                 })
                 .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());
+
+        private static void SetupInstanceFileLogging(LoggerConfiguration log)
+        {
+            log.WriteTo.Map(
+                "Instance",
+                "(watchdog)",
+                (instance, writeTo) => writeTo.File(
+                    Path.Combine("logs", SanitizePathSegment(instance), "watchdog-.log"),
+                    rollingInterval: RollingInterval.Day,
+                    retainedFileCountLimit: 14,
+                    restrictedToMinimumLevel: LogEventLevel.Debug,
+                    outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3} {SourceContext}] {Message:lj}{NewLine}{Exception}"),
+                sinkMapCountLimit: 64);
+        }
+
+        private static string SanitizePathSegment(string value)
+        {
+            var invalid = Path.GetInvalidFileNameChars();
+            return string.Concat(value.Select(c => invalid.Contains(c) ? '_' : c)).Trim();
+        }
 
         private static void SetupLoki(LoggerConfiguration log, IConfiguration cfg)
         {

--- a/SS14.Watchdog/Properties/launchSettings.json
+++ b/SS14.Watchdog/Properties/launchSettings.json
@@ -5,7 +5,24 @@
       "commandName": "Project",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    },
+    "Local": {
+      "commandName": "Project",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Local",
+        "DOTNET_ENVIRONMENT": "Local"
+      }
+    },
+    "Starter": {
+      "commandName": "Project",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Starter",
+        "DOTNET_ENVIRONMENT": "Starter"
       }
     }
   }

--- a/SS14.Watchdog/SS14.Watchdog.csproj
+++ b/SS14.Watchdog/SS14.Watchdog.csproj
@@ -5,6 +5,7 @@
         <Nullable>enable</Nullable>
         <Version>0.3.0</Version>
         <ServerGarbageCollection>false</ServerGarbageCollection>
+        <DefaultItemExcludes>$(DefaultItemExcludes);instances\**</DefaultItemExcludes>
     </PropertyGroup>
 
     <ItemGroup>
@@ -16,15 +17,27 @@
       <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
       <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+      <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
       <PackageReference Include="Serilog.Sinks.Loki" Version="3.0.1-beta1" />
+      <PackageReference Include="System.Resources.Extensions" Version="10.0.0" />
       <PackageReference Include="Dapper" Version="2.1.66" />
       <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.2" />
+      <PackageReference Include="Serilog.Sinks.Map" Version="2.0.0" />
       <PackageReference Include="Tmds.DBus" Version="0.23.0" />
     </ItemGroup>
 
     <ItemGroup>
       <None Update="appsettings.yml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="appsettings.Local.yml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="appsettings.Starter.yml">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="appsettings.Development.yml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </None>
         <Content Remove="Utility\runtime.json" />
         <EmbeddedResource Include="Utility\runtime.json">

--- a/SS14.Watchdog/appsettings.Local.yml
+++ b/SS14.Watchdog/appsettings.Local.yml
@@ -30,7 +30,7 @@ Process:
   LaunchInNewWindow: true
 
 Servers:
-  InstanceRoot: "bin/instances"
+  InstanceRoot: "instances"
   Instances:
     local_one:
       Name: "Local One"

--- a/SS14.Watchdog/appsettings.Local.yml
+++ b/SS14.Watchdog/appsettings.Local.yml
@@ -1,0 +1,53 @@
+Serilog:
+  Using: [ "Serilog.Sinks.Console", "Serilog.Sinks.File", "Serilog.Sinks.Map" ]
+  MinimumLevel:
+    Default: Information
+    Override:
+      SS14: Debug
+      Microsoft: Warning
+      Microsoft.Hosting.Lifetime: Information
+
+  WriteTo:
+    - Name: Console
+      Args:
+        Theme: "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"
+        OutputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3} {SourceContext}] {Message:lj}{NewLine}{Exception}"
+    - Name: File
+      Args:
+        Path: "logs/watchdog-.log"
+        RollingInterval: Day
+        RetainedFileCountLimit: 14
+        OutputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3} {SourceContext}] {Message:lj}{NewLine}{Exception}"
+
+BaseUrl: "http://localhost:5000/"
+
+Data:
+  File: "bin/local-data.db"
+
+Process:
+  Mode: Basic
+  PersistServers: false
+  LaunchInNewWindow: true
+
+Servers:
+  InstanceRoot: "bin/instances"
+  Instances:
+    local_one:
+      Name: "Local One"
+      ApiToken: "local-dev-token-one"
+      ApiPort: 1212
+      RunCommand: "../space-station-14/bin/Content.Server/Content.Server"
+      UpdateType: Local
+      Updates:
+        CurrentVersion: "local-dev"
+      TimeoutSeconds: 90
+
+    # local_two:
+    #   Name: "Local Two"
+    #   ApiToken: "local-dev-token-two"
+    #   ApiPort: 1213
+    #   RunCommand: "../space-station-14/bin/Content.Server/Content.Server"
+    #   UpdateType: Local
+    #   Updates:
+    #     CurrentVersion: "local-dev"
+    #   TimeoutSeconds: 90

--- a/SS14.Watchdog/appsettings.Starter.yml
+++ b/SS14.Watchdog/appsettings.Starter.yml
@@ -1,0 +1,45 @@
+Serilog:
+  Using: [ "Serilog.Sinks.Console", "Serilog.Sinks.File", "Serilog.Sinks.Map" ]
+  MinimumLevel:
+    Default: Information
+    Override:
+      SS14: Information
+      Microsoft: Warning
+      Microsoft.Hosting.Lifetime: Information
+
+  WriteTo:
+    - Name: Console
+      Args:
+        OutputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3} {SourceContext}] {Message:lj}{NewLine}{Exception}"
+    - Name: File
+      Args:
+        Path: "logs/watchdog-.log"
+        RollingInterval: Day
+        RetainedFileCountLimit: 14
+        OutputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} {Level:u3} {SourceContext}] {Message:lj}{NewLine}{Exception}"
+
+# Public URL where players can reach watchdog's static binaries endpoint.
+# Required when Git Updates:HybridACZ is false.
+# BaseUrl: "http://192.168.0.1:5000/"
+
+Data:
+  File: "data.db"
+
+Process:
+  Mode: Basic
+  PersistServers: false
+  LaunchInNewWindow: true
+
+Servers:
+  InstanceRoot: "instances"
+  Instances:
+    main:
+      Name: "My SS14 Server"
+      ApiToken: ""  # Change this to random text.
+      ApiPort: 1212
+      UpdateType: Git
+      Updates:
+        BaseUrl: "https://github.com/space-wizards/space-station-14.git"
+        Branch: "master"
+        HybridACZ: true
+      TimeoutSeconds: 90

--- a/SS14.Watchdog/appsettings.Starter.yml
+++ b/SS14.Watchdog/appsettings.Starter.yml
@@ -31,7 +31,7 @@ Process:
   LaunchInNewWindow: true
 
 Servers:
-  InstanceRoot: "instances"
+  InstanceRoot: "bin/instances"
   Instances:
     main:
       Name: "My SS14 Server"

--- a/SS14.Watchdog/appsettings.Starter.yml
+++ b/SS14.Watchdog/appsettings.Starter.yml
@@ -31,7 +31,7 @@ Process:
   LaunchInNewWindow: true
 
 Servers:
-  InstanceRoot: "bin/instances"
+  InstanceRoot: "instances"
   Instances:
     main:
       Name: "My SS14 Server"

--- a/run-starter.bat
+++ b/run-starter.bat
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+set ASPNETCORE_ENVIRONMENT=Starter
+set DOTNET_ENVIRONMENT=Starter
+dotnet run --no-launch-profile --project SS14.Watchdog\SS14.Watchdog.csproj

--- a/run-starter.ps1
+++ b/run-starter.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = "Stop"
+$env:ASPNETCORE_ENVIRONMENT = "Starter"
+$env:DOTNET_ENVIRONMENT = "Starter"
+dotnet run --no-launch-profile --project SS14.Watchdog/SS14.Watchdog.csproj

--- a/run-starter.ps1
+++ b/run-starter.ps1
@@ -1,4 +1,0 @@
-$ErrorActionPreference = "Stop"
-$env:ASPNETCORE_ENVIRONMENT = "Starter"
-$env:DOTNET_ENVIRONMENT = "Starter"
-dotnet run --no-launch-profile --project SS14.Watchdog/SS14.Watchdog.csproj

--- a/run-starter.sh
+++ b/run-starter.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export ASPNETCORE_ENVIRONMENT=Starter
+export DOTNET_ENVIRONMENT=Starter
+
+dotnet run --no-launch-profile --project SS14.Watchdog/SS14.Watchdog.csproj


### PR DESCRIPTION
Might point the scripts at bin but the rest is done.

Problems with hosting when I tried 4 years ago:
- config.toml doesn't exist oops watchdog explodes.
- need to manually go and run packaging and build the game and put it in.
- None of the update providers are documented in the README you have to go to the docs repo (dead)  or open up the code.

Timmy Tider does not want to deal with the above if they want to host a server for their friends for a couple weeks.

Hence:
- Added a starter config that will use git update provider (the easiest to use for Timmy Tider), and will automatically grab the latest server_config.toml. It also has a corresponding script to run it. Now all you have to do is tweak appsettings.starter.yml and the config.toml that it has grabbed for you.
- README has actual instructions on basic setup and what to change for long-term hosting.
- Makes blank folders / config.toml now regardless of update provider.
- Git update provider has more logs.

This should hopefully significantly reduce the barrier of entry to beginner hosting. Setting up the other parts (e.g. CDN, manifest, etc.) we should also not have in hacky scripts around the place but gotta start with entry-level if we want the game to grow.